### PR TITLE
docs: update API examples with enhanced Mt5ReportClient functionality

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -46,16 +46,20 @@ with Mt5Client(mt5=mt5) as client:
     account = client.account_info()
     rates = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
-# Pandas-friendly interface with Mt5DataClient
+# Pandas-friendly interface with Mt5DataClient and configuration
 config = Mt5Config(login=12345, password="pass", server="MetaQuotes-Demo")
 with Mt5DataClient(mt5=mt5, config=config) as client:
     symbols_df = client.symbols_get()
     rates_df = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
-# Enhanced functionality with Mt5ReportClient
+# Enhanced functionality with Mt5ReportClient for data analysis and export
 with Mt5ReportClient(mt5=mt5, config=config) as reporter:
-    reporter.print_rates("EURUSD", timeframe="H1", count=10)
-    reporter.export_rates_to_csv("EURUSD", "data.csv", timeframe="D1", count=100)
+    # Display formatted data
+    reporter.print_df(rates_df, include_index=True)
+    reporter.print_json(account._asdict() if hasattr(account, '_asdict') else account)
+    
+    # Export data to various formats
+    reporter.export_to_sqlite("trading_data.db", "rates", rates_df)
 ```
 
 ## Examples

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,11 +55,13 @@ with Mt5DataClient(mt5=mt5, config=config) as client:
 # Enhanced functionality with Mt5ReportClient for data analysis and export
 with Mt5ReportClient(mt5=mt5, config=config) as reporter:
     # Display formatted data
-    reporter.print_df(rates_df, include_index=True)
-    reporter.print_json(account._asdict() if hasattr(account, '_asdict') else account)
+    Mt5ReportClient.print_df(rates_df, include_index=True)
+    Mt5ReportClient.print_json(account._asdict() if hasattr(account, '_asdict') else account)
     
-    # Export data to various formats
-    reporter.export_to_sqlite("trading_data.db", "rates", rates_df)
+    # Print with optional SQLite export
+    reporter.print_rates("EURUSD", mt5.TIMEFRAME_H1, 100,
+                        sqlite3_file_path="trading_data.db", 
+                        sqlite3_table="eurusd_rates")
 ```
 
 ## Examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,11 +43,13 @@ with Mt5DataClient(mt5=mt5, config=config) as client:
 # Enhanced functionality with reporting and export
 with Mt5ReportClient(mt5=mt5, config=config) as reporter:
     # Print data with custom formatting
-    reporter.print_df(rates_df)
-    reporter.print_json(account)
+    Mt5ReportClient.print_df(rates_df, include_index=True)
+    Mt5ReportClient.print_json(account._asdict() if hasattr(account, '_asdict') else account)
     
-    # Export to various formats
-    reporter.export_to_sqlite("trading_data.db", "rates", rates_df)
+    # Print with optional SQLite export
+    reporter.print_rates("EURUSD", mt5.TIMEFRAME_H1, 100, 
+                        sqlite3_file_path="trading_data.db", 
+                        sqlite3_table="eurusd_rates")
 ```
 
 ## Requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,19 +29,25 @@ from datetime import datetime
 # Configure connection
 config = Mt5Config(login=12345, password="pass", server="MetaQuotes-Demo")
 
-# Low-level API access
-with Mt5Client(mt5=mt5, config=config) as client:
+# Low-level API access with context manager
+with Mt5Client(mt5=mt5) as client:
+    client.initialize()
+    account = client.account_info()
     rates = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
-# Pandas-friendly interface
+# Pandas-friendly interface with automatic initialization
 with Mt5DataClient(mt5=mt5, config=config) as client:
     symbols_df = client.symbols_get()
     rates_df = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
 # Enhanced functionality with reporting and export
 with Mt5ReportClient(mt5=mt5, config=config) as reporter:
-    reporter.print_rates("EURUSD", timeframe="H1", count=10)
-    reporter.export_rates_to_csv("EURUSD", "data.csv", timeframe="D1", count=100)
+    # Print data with custom formatting
+    reporter.print_df(rates_df)
+    reporter.print_json(account)
+    
+    # Export to various formats
+    reporter.export_to_sqlite("trading_data.db", "rates", rates_df)
 ```
 
 ## Requirements

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -38,7 +38,7 @@ class Mt5DataClient(Mt5Client):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     config: Mt5Config = Field(
-        default_factory=lambda: Mt5Config(),  # type: ignore[reportCallIssue] # noqa: PLW0108
+        default_factory=Mt5Config,
         description="MetaTrader5 connection configuration",
     )
     retry_count: int = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.0.4"
+version = "0.0.5"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
• Updated documentation examples to reflect new Mt5ReportClient capabilities
• Added examples for data formatting methods (print_df, print_json)
• Updated export examples to use SQLite export functionality
• Improved clarity of context manager usage patterns

## Test plan
- [x] Documentation builds successfully with `uv run mkdocs build`
- [x] All linting and type checks pass
- [x] Examples are consistent with current API

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified usage examples for Mt5DataClient and Mt5ReportClient, including detailed initialization steps and enhanced reporting/export operations.
  * Updated comments and instructions to emphasize configuration usage and data export options, such as exporting to SQLite with deduplication and printing in various formats.
  * Added new print methods to Mt5ReportClient for comprehensive market, account, and trading data reporting.
  * Improved clarity in low-level and pandas-friendly API examples to better illustrate client initialization and data handling.
* **Chores**
  * Updated project version from 0.0.4 to 0.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->