### PR TITLE
Fix trading module method calls and exception handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Uses MkDocs with Material theme for API documentation built from Google-style do
 
 ## Web Search Instructions
 
-For tasks requiring web search, always use Gemini CLI (`gemini` command) instead of the built-in web search tools (WebFetch or WebSearch).
+For tasks requiring web search, always use Gemini CLI (`gemini` command) instead of the built-in web search tools (WebFetch and WebSearch).
 Gemini CLI is an AI workflow tool that provides reliable web search capabilities.
 
 ### Usage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Uses MkDocs with Material theme for API documentation built from Google-style do
 
 ## Web Search Instructions
 
-For tasks requiring web search, always use Gemini CLI (`gemini` command) instead of the built-in web search tool.
+For tasks requiring web search, always use Gemini CLI (`gemini` command) instead of the built-in web search tools (WebFetch or WebSearch).
 Gemini CLI is an AI workflow tool that provides reliable web search capabilities.
 
 ### Usage

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -161,13 +161,13 @@ class Mt5TradingClient(Mt5DataClient):
         """
         symbol_info = self.symbol_info_as_dict(symbol=symbol)
         symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
-        min_ask_order_margin = self.mt5.order_calc_margin(
+        min_ask_order_margin = self.order_calc_margin(
             action=self.mt5.ORDER_TYPE_BUY,
             symbol=symbol,
             volume=symbol_info["volume_min"],
             price=symbol_info_tick["ask"],
         )
-        min_bid_order_margin = self.mt5.order_calc_margin(
+        min_bid_order_margin = self.order_calc_margin(
             action=self.mt5.ORDER_TYPE_SELL,
             symbol=symbol,
             volume=symbol_info["volume_min"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.0.9"
+version = "0.1.0"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/test/test_trading.py
+++ b/test/test_trading.py
@@ -642,17 +642,17 @@ class TestMt5TradingClient:
 
         # Verify first call (buy order)
         first_call = mock_mt5_import.order_calc_margin.call_args_list[0]
-        assert first_call[1]["action"] == mock_mt5_import.ORDER_TYPE_BUY
-        assert first_call[1]["symbol"] == "EURUSD"
-        assert first_call[1]["volume"] == 0.01
-        assert first_call[1]["price"] == 1.1000
+        assert first_call[0][0] == mock_mt5_import.ORDER_TYPE_BUY  # action
+        assert first_call[0][1] == "EURUSD"  # symbol
+        assert first_call[0][2] == 0.01  # volume
+        assert first_call[0][3] == 1.1000  # price
 
         # Verify second call (sell order)
         second_call = mock_mt5_import.order_calc_margin.call_args_list[1]
-        assert second_call[1]["action"] == mock_mt5_import.ORDER_TYPE_SELL
-        assert second_call[1]["symbol"] == "EURUSD"
-        assert second_call[1]["volume"] == 0.01
-        assert second_call[1]["price"] == 1.0998
+        assert second_call[0][0] == mock_mt5_import.ORDER_TYPE_SELL  # action
+        assert second_call[0][1] == "EURUSD"  # symbol
+        assert second_call[0][2] == 0.01  # volume
+        assert second_call[0][3] == 1.0998  # price
 
     def test_calculate_minimum_order_margins_failure_ask(
         self,
@@ -678,12 +678,8 @@ class TestMt5TradingClient:
         # Mock order_calc_margin to return None for ask margin
         mock_mt5_import.order_calc_margin.side_effect = [None, 99.8]
 
-        with pytest.raises(Mt5TradingError) as exc_info:
+        with pytest.raises(Mt5RuntimeError):
             client.calculate_minimum_order_margins("EURUSD")
-
-        assert "Failed to calculate minimum order margins for symbol: EURUSD" in str(
-            exc_info.value
-        )
 
     def test_calculate_minimum_order_margins_failure_bid(
         self,
@@ -709,12 +705,8 @@ class TestMt5TradingClient:
         # Mock order_calc_margin to return None for bid margin
         mock_mt5_import.order_calc_margin.side_effect = [100.5, None]
 
-        with pytest.raises(Mt5TradingError) as exc_info:
+        with pytest.raises(Mt5RuntimeError):
             client.calculate_minimum_order_margins("EURUSD")
-
-        assert "Failed to calculate minimum order margins for symbol: EURUSD" in str(
-            exc_info.value
-        )
 
     def test_calculate_minimum_order_margins_failure_both(
         self,
@@ -740,9 +732,5 @@ class TestMt5TradingClient:
         # Mock order_calc_margin to return None for both margins
         mock_mt5_import.order_calc_margin.side_effect = [None, None]
 
-        with pytest.raises(Mt5TradingError) as exc_info:
+        with pytest.raises(Mt5RuntimeError):
             client.calculate_minimum_order_margins("EURUSD")
-
-        assert "Failed to calculate minimum order margins for symbol: EURUSD" in str(
-            exc_info.value
-        )

--- a/test/test_trading.py
+++ b/test/test_trading.py
@@ -729,8 +729,8 @@ class TestMt5TradingClient:
             "bid": 1.0998,
         }
 
-        # Mock order_calc_margin to return None for both margins
-        mock_mt5_import.order_calc_margin.side_effect = [None, None]
+        # Mock order_calc_margin to return 0.0 for both margins (indicates failure)
+        mock_mt5_import.order_calc_margin.side_effect = [0.0, 0.0]
 
-        with pytest.raises(Mt5RuntimeError):
+        with pytest.raises(Mt5TradingError):
             client.calculate_minimum_order_margins("EURUSD")

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.0.9"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
- Fixed `order_calc_margin` calls in trading module to use instance method instead of mt5 attribute
- Updated tests to use positional arguments for mocked method calls
- Corrected exception handling in tests to expect `Mt5RuntimeError`

## Test plan
- [x] Run unit tests with `uv run pytest test/`
- [x] Type checking with `uv run pyright .`
- [x] Linting with `uv run ruff check .`
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified web search instructions to specify using the Gemini CLI instead of built-in tools, naming "WebFetch" and "WebSearch" as tools to avoid.
* **Bug Fixes**
  * Adjusted margin calculation method to improve how order margins are computed internally.
* **Tests**
  * Updated test assertions to reflect changes in how margin calculation is invoked and modified expected exception types in failure scenarios.
* **Chores**
  * Bumped project version from 0.0.9 to 0.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->