### PR TITLE
refactor: simplify MT5 initialization API

### DIFF
--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -106,7 +106,6 @@ class Mt5Client(BaseModel):
         password: str | None = None,
         server: str | None = None,
         timeout: int | None = None,
-        portable: bool | None = None,
     ) -> bool:
         """Establish a connection with the MetaTrader 5 terminal.
 
@@ -116,7 +115,6 @@ class Mt5Client(BaseModel):
             password: Trading account password.
             server: Trade server address.
             timeout: Connection timeout in milliseconds.
-            portable: Use portable mode.
 
         Returns:
             True if successful, False otherwise.
@@ -135,7 +133,6 @@ class Mt5Client(BaseModel):
                         "password": password,
                         "server": server,
                         "timeout": timeout,
-                        "portable": portable,
                     }.items()
                     if v is not None
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/test/test_mt5.py
+++ b/test/test_mt5.py
@@ -88,7 +88,6 @@ class TestMt5Client:
             password="secret",
             server="Demo",
             timeout=60000,
-            portable=True,
         )
 
         assert result is True
@@ -98,7 +97,6 @@ class TestMt5Client:
             password="secret",
             server="Demo",
             timeout=60000,
-            portable=True,
         )
 
     def test_initialize_failure(self, client: Mt5Client, mock_mt5: Mock) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
- Removed unused `portable` parameter from MT5 configuration and initialization methods
- Renamed `initialize_mt5()` to `initialize_and_login_mt5()` to better reflect its functionality
- Combined MT5 initialization and login operations into a single method call

## Changes
- Updated `Mt5Config` to remove the `portable` field
- Modified `Mt5Client.initialize()` to remove the `portable` parameter
- Renamed and refactored `Mt5DataClient.initialize_mt5()` to `initialize_and_login_mt5()`
- Updated all related tests to reflect the API changes
- Bumped version to v0.1.1

## Test plan
- [x] All existing tests pass
- [x] Test coverage remains at 100%
- [x] Type checking passes with pyright strict mode
- [x] Linting passes with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)