### PR TITLE
Fix dry run mode parameter handling in Mt5TradingClient

### DIFF
--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -32,6 +32,7 @@ class Mt5TradingClient(Mt5DataClient):
     def close_open_positions(
         self,
         symbols: str | list[str] | tuple[str, ...] | None = None,
+        dry_run: bool | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> dict[str, list[dict[str, Any]]]:
         """Close all open positions for specified symbols.
@@ -39,6 +40,8 @@ class Mt5TradingClient(Mt5DataClient):
         Args:
             symbols: Optional symbol or list of symbols to filter positions.
                 If None, all symbols will be considered.
+            dry_run: Optional flag to enable dry run mode. If None, uses the instance's
+                `dry_run` attribute.
             **kwargs: Additional keyword arguments for request parameters.
 
         Returns:
@@ -53,18 +56,22 @@ class Mt5TradingClient(Mt5DataClient):
             symbol_list = self.symbols_get()
         self.logger.info("Fetching and closing positions for symbols: %s", symbol_list)
         return {
-            s: self._fetch_and_close_position(symbol=s, **kwargs) for s in symbol_list
+            s: self._fetch_and_close_position(symbol=s, dry_run=dry_run, **kwargs)
+            for s in symbol_list
         }
 
     def _fetch_and_close_position(
         self,
         symbol: str | None = None,
+        dry_run: bool | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> list[dict[str, Any]]:
         """Close all open positions for a specific symbol.
 
         Args:
             symbol: Optional symbol filter.
+            dry_run: Optional flag to enable dry run mode. If None, uses the instance's
+                `dry_run` attribute.
             **kwargs: Additional keyword arguments for request parameters.
 
         Returns:
@@ -96,6 +103,7 @@ class Mt5TradingClient(Mt5DataClient):
                         "position": p["ticket"],
                         **kwargs,
                     },
+                    dry_run=dry_run,
                 )
                 for p in positions_dict
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.1.1"
+version = "0.1.2"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
- Fixed `__is_dry_run` parameter handling in `close_open_positions` method
- Added comprehensive tests for dry_run parameter override scenarios
- Updated dependencies in uv.lock
- Bumped version to v0.1.2

## Test plan
- [x] Run existing tests with `uv run pytest test/`
- [x] Verify dry run mode works correctly without errors
- [x] Added tests for dry_run parameter override functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to control dry run mode explicitly when closing trading positions, allowing users to override the default setting on a per-call basis.

* **Tests**
  * Introduced new test cases to verify dry run functionality and its overrides when closing positions and sending orders.

* **Chores**
  * Updated project version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->