### PR TITLE
refactor: move order_filling_mode to method parameter and improve margin handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ Extends Mt5Client with pandas DataFrame and dictionary conversions:
 
 Advanced trading operations client that extends Mt5DataClient:
 
-- **Trading Configuration**:
-  - `order_filling_mode` - Order execution mode: "IOC" (default), "FOK", or "RETURN"
-  - `dry_run` - Test mode flag for simulating trades without execution
 - **Position Management**:
   - `close_open_positions()` - Close all positions for specified symbol(s)
   - `place_market_order()` - Place market orders with configurable side, volume, and execution modes
@@ -190,7 +187,6 @@ Advanced trading operations client that extends Mt5DataClient:
   - Comprehensive error handling with `Mt5TradingError`
   - Support for batch operations on multiple symbols
   - Automatic position closing with proper order type reversal
-  - Dry run mode for strategy testing without real trades
 
 ### Configuration
 
@@ -267,8 +263,8 @@ with Mt5DataClient(config=config) as client:
 ```python
 from pdmt5 import Mt5TradingClient
 
-# Create trading client with specific order filling mode
-with Mt5TradingClient(config=config, order_filling_mode="IOC") as trader:
+# Create trading client
+with Mt5TradingClient(config=config) as trader:
     # Place a market buy order
     order_result = trader.place_market_order(
         symbol="EURUSD",
@@ -296,25 +292,16 @@ with Mt5TradingClient(config=config, order_filling_mode="IOC") as trader:
     )
     print(f"New position margin ratio: {margin_ratio:.2%}")
 
-    # Close all EURUSD positions
-    results = trader.close_open_positions(symbols="EURUSD")
+    # Close all EURUSD positions with specific order filling mode
+    results = trader.close_open_positions(
+        symbols="EURUSD",
+        order_filling_mode="FOK"  # Fill or Kill
+    )
 
     if results:
         for symbol, close_results in results.items():
             for result in close_results:
                 print(f"Closed position {result.get('position')} with result: {result['retcode']}")
-
-    # Using dry run mode for testing
-    trader_dry = Mt5TradingClient(config=config, dry_run=True)
-    with trader_dry:
-        # Test placing an order without actual execution
-        test_order = trader_dry.place_market_order(
-            symbol="GBPUSD",
-            volume=0.1,
-            order_side="SELL",
-            dry_run=True  # Override instance setting
-        )
-        print(f"Test order validation: {test_order['retcode']}")
 ```
 
 ### Market Analysis with Mt5TradingClient

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -70,33 +70,34 @@ with client:
 ### Order Filling Modes
 
 ```python
-# Configure different order filling modes
-# IOC (Immediate or Cancel) - default
-client_ioc = Mt5TradingClient(
-    config=config,
-    order_filling_mode="IOC"
-)
+with Mt5TradingClient(config=config) as client:
+    # Use IOC (Immediate or Cancel) - default
+    results_ioc = client.close_open_positions(
+        symbols="EURUSD",
+        order_filling_mode="IOC"
+    )
 
-# FOK (Fill or Kill)
-client_fok = Mt5TradingClient(
-    config=config,
-    order_filling_mode="FOK"
-)
+    # Use FOK (Fill or Kill)
+    results_fok = client.close_open_positions(
+        symbols="GBPUSD",
+        order_filling_mode="FOK"
+    )
 
-# RETURN (Return if not filled)
-client_return = Mt5TradingClient(
-    config=config,
-    order_filling_mode="RETURN"
-)
+    # Use RETURN (Return if not filled)
+    results_return = client.close_open_positions(
+        symbols="USDJPY",
+        order_filling_mode="RETURN"
+    )
 ```
 
 ### Custom Order Parameters
 
 ```python
 with client:
-    # Close positions with custom parameters
+    # Close positions with custom parameters and order filling mode
     results = client.close_open_positions(
         "EURUSD",
+        order_filling_mode="IOC",  # Specify per method call
         comment="Closing all EURUSD positions",
         deviation=10  # Maximum price deviation
     )

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from math import floor
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict
 
 from .dataframe import Mt5DataClient
 from .mt5 import Mt5RuntimeError
@@ -27,11 +27,6 @@ class Mt5TradingClient(Mt5DataClient):
     """
 
     model_config = ConfigDict(frozen=True)
-    order_filling_mode: Literal["IOC", "FOK", "RETURN"] = Field(
-        default="IOC",
-        description="Order filling mode: 'IOC' (Immediate or Cancel), "
-        "'FOK' (Fill or Kill), 'RETURN' (Return if not filled)",
-    )
 
     def close_open_positions(
         self,
@@ -66,6 +61,7 @@ class Mt5TradingClient(Mt5DataClient):
     def _fetch_and_close_position(
         self,
         symbol: str | None = None,
+        order_filling_mode: Literal["IOC", "FOK", "RETURN"] = "IOC",
         dry_run: bool = False,
         **kwargs: Any,  # noqa: ANN401
     ) -> list[dict[str, Any]]:
@@ -73,6 +69,7 @@ class Mt5TradingClient(Mt5DataClient):
 
         Args:
             symbol: Optional symbol filter.
+            order_filling_mode: Order filling mode, either "IOC", "FOK", or "RETURN".
             dry_run: If True, only check the order without sending it.
             **kwargs: Additional keyword arguments for request parameters.
 
@@ -85,10 +82,6 @@ class Mt5TradingClient(Mt5DataClient):
             return []
         else:
             self.logger.info("Closing open positions for symbol: %s", symbol)
-            order_filling_type = getattr(
-                self.mt5,
-                f"ORDER_FILLING_{self.order_filling_mode}",
-            )
             return [
                 self._send_or_check_order(
                     request={
@@ -100,7 +93,10 @@ class Mt5TradingClient(Mt5DataClient):
                             if p["type"] == self.mt5.POSITION_TYPE_BUY
                             else self.mt5.ORDER_TYPE_BUY
                         ),
-                        "type_filling": order_filling_type,
+                        "type_filling": getattr(
+                            self.mt5,
+                            f"ORDER_FILLING_{order_filling_mode}",
+                        ),
                         "type_time": self.mt5.ORDER_TIME_GTC,
                         "position": p["ticket"],
                         **kwargs,
@@ -280,19 +276,25 @@ class Mt5TradingClient(Mt5DataClient):
         """
         symbol_info = self.symbol_info_as_dict(symbol=symbol)
         symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
-        return {
-            "volume": symbol_info["volume_min"],
-            "margin": self.order_calc_margin(
-                action=getattr(self.mt5, f"ORDER_TYPE_{order_side.upper()}"),
-                symbol=symbol,
-                volume=symbol_info["volume_min"],
-                price=(
-                    symbol_info_tick["bid"]
-                    if order_side == "SELL"
-                    else symbol_info_tick["ask"]
-                ),
+        margin = self.order_calc_margin(
+            action=getattr(self.mt5, f"ORDER_TYPE_{order_side.upper()}"),
+            symbol=symbol,
+            volume=symbol_info["volume_min"],
+            price=(
+                symbol_info_tick["bid"]
+                if order_side == "SELL"
+                else symbol_info_tick["ask"]
             ),
-        }
+        )
+        if margin:
+            return {"volume": symbol_info["volume_min"], "margin": margin}
+        else:
+            self.logger.warning(
+                "No margin available for symbol: %s with order side: %s",
+                symbol,
+                order_side,
+            )
+            return {"volume": symbol_info["volume_min"], "margin": 0.0}
 
     def calculate_volume_by_margin(
         self,
@@ -314,10 +316,13 @@ class Mt5TradingClient(Mt5DataClient):
             symbol=symbol,
             order_side=order_side,
         )
-        return (
-            floor(margin / min_order_margin_dict["margin"])
-            * min_order_margin_dict["volume"]
-        )
+        if min_order_margin_dict["margin"]:
+            return (
+                floor(margin / min_order_margin_dict["margin"])
+                * min_order_margin_dict["volume"]
+            )
+        else:
+            return 0.0
 
     def calculate_spread_ratio(
         self,

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -31,6 +31,7 @@ class Mt5TradingClient(Mt5DataClient):
     def close_open_positions(
         self,
         symbols: str | list[str] | tuple[str, ...] | None = None,
+        order_filling_mode: Literal["IOC", "FOK", "RETURN"] = "IOC",
         dry_run: bool = False,
         **kwargs: Any,  # noqa: ANN401
     ) -> dict[str, list[dict[str, Any]]]:
@@ -39,6 +40,7 @@ class Mt5TradingClient(Mt5DataClient):
         Args:
             symbols: Optional symbol or list of symbols to filter positions.
                 If None, all symbols will be considered.
+            order_filling_mode: Order filling mode, either "IOC", "FOK", or "RETURN".
             dry_run: If True, only check the order without sending it.
             **kwargs: Additional keyword arguments for request parameters.
 
@@ -54,7 +56,12 @@ class Mt5TradingClient(Mt5DataClient):
             symbol_list = self.symbols_get()
         self.logger.info("Fetching and closing positions for symbols: %s", symbol_list)
         return {
-            s: self._fetch_and_close_position(symbol=s, dry_run=dry_run, **kwargs)
+            s: self._fetch_and_close_position(
+                symbol=s,
+                order_filling_mode=order_filling_mode,
+                dry_run=dry_run,
+                **kwargs,
+            )
             for s in symbol_list
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.1.6"
+version = "0.1.7"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
- Move `order_filling_mode` from class attribute to method parameter for more flexible usage
- Add proper error handling for zero margin scenarios in margin calculations
- Update version to 0.1.7

## Test plan
- [x] All existing unit tests pass
- [x] Added new tests for zero margin scenarios
- [x] Verified parameter changes in `_fetch_and_close_position` method
- [x] Type checking passes with pyright

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced margin calculation methods to handle zero-margin scenarios gracefully, providing clear warnings and fallback values.
* **Bug Fixes**
  * Improved validation and parameter handling for order filling mode, now requiring it as a method parameter rather than a class attribute.
* **Documentation**
  * Updated usage examples to reflect per-call specification of order filling mode instead of client initialization.
* **Tests**
  * Updated and expanded test coverage to reflect changes in order filling mode handling and to ensure correct behavior with zero-margin cases.
* **Chores**
  * Updated project version to 0.1.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->