### PR TITLE
Add CLI interface for MetaTrader5 data export

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,296 @@
+# CLI Reference
+
+The `pdmt5` command-line interface exports MetaTrader 5 data to CSV, JSON, Parquet, or SQLite3 files.
+
+## Installation
+
+The CLI is included with the pdmt5 package:
+
+```bash
+pip install pdmt5
+```
+
+After installation, the `pdmt5` command is available:
+
+```bash
+pdmt5 --help
+```
+
+You can also run it as a Python module:
+
+```bash
+python -m pdmt5 --help
+```
+
+## Global Options
+
+All subcommands share these options, which must appear **before** the subcommand name:
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `-o`, `--output` | `PATH` | Yes | Output file path. |
+| `-f`, `--format` | `csv\|json\|parquet\|sqlite3` | No | Output format (auto-detected from extension if omitted). |
+| `--table` | `TEXT` | No | Table name for SQLite3 output (default: `data`). |
+| `--login` | `INT` | No | Trading account login. |
+| `--password` | `TEXT` | No | Trading account password. |
+| `--server` | `TEXT` | No | Trading server name. |
+| `--path` | `TEXT` | No | Path to MetaTrader 5 terminal EXE file. |
+| `--timeout` | `INT` | No | Connection timeout in milliseconds. |
+| `--log-level` | `DEBUG\|INFO\|WARNING\|ERROR` | No | Logging level (default: `WARNING`). |
+
+### Format Auto-Detection
+
+When `--format` is omitted, the output format is inferred from the file extension:
+
+| Extension | Format |
+|-----------|--------|
+| `.csv` | CSV |
+| `.json` | JSON |
+| `.parquet`, `.pq` | Parquet |
+| `.db`, `.sqlite`, `.sqlite3` | SQLite3 |
+
+## Subcommands
+
+### Market Data
+
+#### `rates-from`
+
+Export OHLCV rates from a start date.
+
+```bash
+pdmt5 -o rates.csv rates-from \
+  --symbol EURUSD --timeframe M1 \
+  --date-from 2024-01-01 --count 1000
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+| `--timeframe` | `TIMEFRAME` | Yes | Timeframe (e.g., `M1`, `H1`, `D1`, or integer). |
+| `--date-from` | `DATETIME` | Yes | Start date in ISO 8601 format. |
+| `--count` | `INT` | Yes | Number of records. |
+
+#### `rates-from-pos`
+
+Export OHLCV rates from a bar position.
+
+```bash
+pdmt5 -o rates.json rates-from-pos \
+  --symbol GBPUSD --timeframe H1 \
+  --start-pos 0 --count 100
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+| `--timeframe` | `TIMEFRAME` | Yes | Timeframe. |
+| `--start-pos` | `INT` | Yes | Start position (0 = current bar). |
+| `--count` | `INT` | Yes | Number of records. |
+
+#### `rates-range`
+
+Export OHLCV rates for a date range.
+
+```bash
+pdmt5 -o rates.parquet rates-range \
+  --symbol USDJPY --timeframe D1 \
+  --date-from 2024-01-01 --date-to 2024-06-01
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+| `--timeframe` | `TIMEFRAME` | Yes | Timeframe. |
+| `--date-from` | `DATETIME` | Yes | Start date. |
+| `--date-to` | `DATETIME` | Yes | End date. |
+
+#### `ticks-from`
+
+Export tick data from a start date.
+
+```bash
+pdmt5 -o ticks.csv ticks-from \
+  --symbol EURUSD --date-from 2024-01-01 \
+  --count 5000 --flags ALL
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+| `--date-from` | `DATETIME` | Yes | Start date. |
+| `--count` | `INT` | Yes | Number of ticks. |
+| `--flags` | `FLAGS` | Yes | Tick flags (`ALL`, `INFO`, `TRADE`, or integer). |
+
+#### `ticks-range`
+
+Export tick data for a date range.
+
+```bash
+pdmt5 -o ticks.db ticks-range \
+  --symbol EURUSD --date-from 2024-01-01 \
+  --date-to 2024-02-01 --flags INFO
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+| `--date-from` | `DATETIME` | Yes | Start date. |
+| `--date-to` | `DATETIME` | Yes | End date. |
+| `--flags` | `FLAGS` | Yes | Tick flags. |
+
+### Account & Terminal
+
+#### `account-info`
+
+Export trading account information.
+
+```bash
+pdmt5 -o account.json account-info
+```
+
+#### `terminal-info`
+
+Export MetaTrader 5 terminal information.
+
+```bash
+pdmt5 -o terminal.csv terminal-info
+```
+
+### Symbols
+
+#### `symbols`
+
+Export the list of available symbols.
+
+```bash
+pdmt5 -o symbols.csv symbols --group "*USD*"
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--group` | `TEXT` | No | Symbol group filter (e.g., `*USD*`). |
+
+#### `symbol-info`
+
+Export detailed information for a single symbol.
+
+```bash
+pdmt5 -o eurusd.json symbol-info --symbol EURUSD
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | Yes | Symbol name. |
+
+### Orders & Positions
+
+#### `orders`
+
+Export active (pending) orders.
+
+```bash
+pdmt5 -o orders.csv orders --symbol EURUSD
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | No | Symbol filter. |
+| `--group` | `TEXT` | No | Group filter. |
+| `--ticket` | `INT` | No | Ticket filter. |
+
+#### `positions`
+
+Export open positions.
+
+```bash
+pdmt5 -o positions.csv positions --group "*USD*"
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--symbol` | `TEXT` | No | Symbol filter. |
+| `--group` | `TEXT` | No | Group filter. |
+| `--ticket` | `INT` | No | Ticket filter. |
+
+### History
+
+#### `history-orders`
+
+Export historical orders.
+
+```bash
+pdmt5 -o hist_orders.csv history-orders \
+  --date-from 2024-01-01 --date-to 2024-06-01
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--date-from` | `DATETIME` | No | Start date. |
+| `--date-to` | `DATETIME` | No | End date. |
+| `--group` | `TEXT` | No | Group filter. |
+| `--symbol` | `TEXT` | No | Symbol filter. |
+| `--ticket` | `INT` | No | Order ticket. |
+| `--position` | `INT` | No | Position ticket. |
+
+#### `history-deals`
+
+Export historical deals.
+
+```bash
+pdmt5 -o deals.parquet history-deals \
+  --date-from 2024-01-01 --date-to 2024-06-01
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--date-from` | `DATETIME` | No | Start date. |
+| `--date-to` | `DATETIME` | No | End date. |
+| `--group` | `TEXT` | No | Group filter. |
+| `--symbol` | `TEXT` | No | Symbol filter. |
+| `--ticket` | `INT` | No | Order ticket. |
+| `--position` | `INT` | No | Position ticket. |
+
+## Custom Types
+
+### `DATETIME`
+
+ISO 8601 datetime strings. A UTC timezone is assumed when none is specified.
+
+- `2024-01-15` (date only, interpreted as midnight UTC)
+- `2024-01-15T12:00:00+00:00` (full datetime with timezone)
+
+### `TIMEFRAME`
+
+MetaTrader 5 timeframe names or integer values:
+
+| Name | Value | Name | Value |
+|------|-------|------|-------|
+| `M1` | 1 | `H1` | 16385 |
+| `M2` | 2 | `H2` | 16386 |
+| `M3` | 3 | `H3` | 16387 |
+| `M4` | 4 | `H4` | 16388 |
+| `M5` | 5 | `H6` | 16390 |
+| `M6` | 6 | `H8` | 16392 |
+| `M10` | 10 | `H12` | 16396 |
+| `M12` | 12 | `D1` | 16408 |
+| `M15` | 15 | `W1` | 32769 |
+| `M20` | 20 | `MN1` | 49153 |
+| `M30` | 30 | | |
+
+### `FLAGS`
+
+Tick copy flags:
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `ALL` | 1 | All ticks. |
+| `INFO` | 2 | Ticks with bid/ask changes. |
+| `TRADE` | 4 | Ticks with last price and volume changes. |
+
+## Public API
+
+The `detect_format` and `export_dataframe` functions are also available as library imports:
+
+::: pdmt5.cli.detect_format
+
+::: pdmt5.cli.export_dataframe

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,6 +6,10 @@ This section contains the complete API documentation for pdmt5.
 
 The pdmt5 package consists of the following modules:
 
+### [CLI](cli.md)
+
+Command-line interface for exporting MetaTrader 5 data to CSV, JSON, Parquet, or SQLite3 files.
+
 ### [Mt5Client](mt5.md)
 
 Base client class for MetaTrader 5 operations with connection management, low-level API access, and error handling (`Mt5RuntimeError`).
@@ -26,6 +30,7 @@ The package follows a layered architecture:
 2. **Data Layer** (`dataframe.py`): Extends `Mt5Client` with configuration (`Mt5Config`) and pandas-friendly `Mt5DataClient` class
 3. **Trading Layer** (`trading.py`): Extends `Mt5DataClient` with advanced trading operations and `Mt5TradingError` exception
 4. **Utilities** (`utils.py`): Helper functions for time conversion and DataFrame manipulation
+5. **CLI** (`cli.py`): Command-line interface for data export using typer
 
 ## Usage Guidelines
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ pdmt5 is a Python library that provides a pandas-based interface for handling Me
 - **Pandas-based**: Leverages pandas for efficient data manipulation
 - **Type Safety**: Built with pydantic for robust data validation
 - **Financial Focus**: Designed specifically for trading and financial data analysis
+- **CLI Export**: Command-line tool for exporting data to CSV, JSON, Parquet, or SQLite3
 
 ## Installation
 
@@ -73,6 +74,7 @@ with Mt5TradingClient(config=config) as client:
 
 Browse the API documentation to learn about available modules and functions:
 
+- [CLI Reference](api/cli.md) - Command-line interface for exporting data to CSV, JSON, Parquet, or SQLite3
 - [Mt5Client](api/mt5.md) - Base client for low-level MT5 API access with context manager support
 - [Mt5DataClient & Mt5Config](api/dataframe.md) - Pandas-friendly data client with DataFrame conversions
 - [Mt5TradingClient](api/trading.md) - Advanced trading operations with position management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Home: index.md
   - API Reference:
     - Overview: api/index.md
+    - CLI: api/cli.md
     - MetaTrader5: api/mt5.md
     - DataFrame: api/dataframe.md
     - Trading: api/trading.md

--- a/pdmt5/__init__.py
+++ b/pdmt5/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import version
 
+from .cli import detect_format, export_dataframe, fetch_data
 from .dataframe import Mt5Config, Mt5DataClient
 from .mt5 import Mt5Client, Mt5RuntimeError
 from .trading import Mt5TradingClient, Mt5TradingError
@@ -15,4 +16,7 @@ __all__ = [
     "Mt5RuntimeError",
     "Mt5TradingClient",
     "Mt5TradingError",
+    "detect_format",
+    "export_dataframe",
+    "fetch_data",
 ]

--- a/pdmt5/__init__.py
+++ b/pdmt5/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import version
 
-from .cli import detect_format, export_dataframe, fetch_data
+from .cli import detect_format, export_dataframe
 from .dataframe import Mt5Config, Mt5DataClient
 from .mt5 import Mt5Client, Mt5RuntimeError
 from .trading import Mt5TradingClient, Mt5TradingError
@@ -18,5 +18,4 @@ __all__ = [
     "Mt5TradingError",
     "detect_format",
     "export_dataframe",
-    "fetch_data",
 ]

--- a/pdmt5/__main__.py
+++ b/pdmt5/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for running pdmt5 as a module via ``python -m pdmt5``."""
+
+from pdmt5.cli import main
+
+main()

--- a/pdmt5/cli.py
+++ b/pdmt5/cli.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
-import argparse
 import logging
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import TYPE_CHECKING
+from enum import StrEnum
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING, Annotated, cast
+
+import click
+import typer
 
 from .dataframe import Mt5Config, Mt5DataClient
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable
 
     import pandas as pd
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
 TIMEFRAME_MAP: dict[str, int] = {
     "M1": 1,
@@ -57,6 +65,144 @@ _FORMAT_EXTENSIONS: dict[str, str] = {
     ".sqlite": "sqlite3",
     ".sqlite3": "sqlite3",
 }
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class OutputFormat(StrEnum):
+    """Supported output file formats."""
+
+    csv = "csv"
+    json = "json"
+    parquet = "parquet"
+    sqlite3 = "sqlite3"
+
+
+class LogLevel(StrEnum):
+    """Logging verbosity levels."""
+
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Click parameter types
+# ---------------------------------------------------------------------------
+
+
+class _DateTimeType(click.ParamType):
+    """Click parameter type for ISO 8601 datetime strings."""
+
+    name = "DATETIME"
+
+    def convert(
+        self,
+        value: object,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> datetime:
+        """Convert a string value to a timezone-aware datetime.
+
+        Args:
+            value: Raw value from the command line.
+            param: Click parameter instance.
+            ctx: Click context.
+
+        Returns:
+            Parsed datetime.
+        """
+        if isinstance(value, datetime):
+            return value
+        try:
+            return parse_datetime(str(value))
+        except ValueError as exc:
+            self.fail(str(exc), param, ctx)
+
+
+class _TimeframeType(click.ParamType):
+    """Click parameter type for MT5 timeframe values."""
+
+    name = "TIMEFRAME"
+
+    def convert(
+        self,
+        value: object,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> int:
+        """Convert a string or integer value to a timeframe integer.
+
+        Args:
+            value: Raw value from the command line.
+            param: Click parameter instance.
+            ctx: Click context.
+
+        Returns:
+            Integer timeframe value.
+        """
+        if isinstance(value, int):
+            return value
+        try:
+            return parse_timeframe(str(value))
+        except ValueError as exc:
+            self.fail(str(exc), param, ctx)
+
+
+class _TickFlagsType(click.ParamType):
+    """Click parameter type for MT5 tick copy flags."""
+
+    name = "FLAGS"
+
+    def convert(
+        self,
+        value: object,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> int:
+        """Convert a string or integer value to a tick flags integer.
+
+        Args:
+            value: Raw value from the command line.
+            param: Click parameter instance.
+            ctx: Click context.
+
+        Returns:
+            Integer tick flag value.
+        """
+        if isinstance(value, int):
+            return value
+        try:
+            return parse_tick_flags(str(value))
+        except ValueError as exc:
+            self.fail(str(exc), param, ctx)
+
+
+DATETIME_TYPE = _DateTimeType()
+TIMEFRAME_TYPE = _TimeframeType()
+TICK_FLAGS_TYPE = _TickFlagsType()
+
+# ---------------------------------------------------------------------------
+# Export context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ExportContext:
+    """Shared context data passed from the callback to each subcommand."""
+
+    output: Path
+    output_format: str
+    table: str
+    config: Mt5Config
+
+
+# ---------------------------------------------------------------------------
+# Public utility functions
+# ---------------------------------------------------------------------------
 
 
 def detect_format(
@@ -107,7 +253,12 @@ def export_dataframe(
     if output_format == "csv":
         df.to_csv(output_path, index=False)
     elif output_format == "json":
-        df.to_json(output_path, orient="records", date_format="iso", indent=2)
+        df.to_json(
+            output_path,
+            orient="records",
+            date_format="iso",
+            indent=2,
+        )
     elif output_format == "parquet":
         df.to_parquet(output_path, index=False)
     elif output_format == "sqlite3":
@@ -134,13 +285,13 @@ def parse_datetime(value: str) -> datetime:
         Parsed datetime with UTC timezone if no timezone is specified.
 
     Raises:
-        argparse.ArgumentTypeError: If the string cannot be parsed.
+        ValueError: If the string cannot be parsed.
     """
     try:
         dt = datetime.fromisoformat(value)
     except ValueError:
         msg = f"Invalid datetime format: '{value}'. Use ISO 8601 format."
-        raise argparse.ArgumentTypeError(msg) from None
+        raise ValueError(msg) from None
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt
@@ -156,7 +307,7 @@ def parse_timeframe(value: str) -> int:
         Integer timeframe value.
 
     Raises:
-        argparse.ArgumentTypeError: If the timeframe is invalid.
+        ValueError: If the timeframe is invalid.
     """
     upper = value.upper()
     if upper in TIMEFRAME_MAP:
@@ -166,7 +317,7 @@ def parse_timeframe(value: str) -> int:
     except ValueError:
         valid = ", ".join(TIMEFRAME_MAP)
         msg = f"Invalid timeframe: '{value}'. Use one of: {valid}, or an integer."
-        raise argparse.ArgumentTypeError(msg) from None
+        raise ValueError(msg) from None
 
 
 def parse_tick_flags(value: str) -> int:
@@ -179,7 +330,7 @@ def parse_tick_flags(value: str) -> int:
         Integer tick flag value.
 
     Raises:
-        argparse.ArgumentTypeError: If the flag is invalid.
+        ValueError: If the flag is invalid.
     """
     upper = value.upper()
     if upper in TICK_FLAG_MAP:
@@ -189,373 +340,414 @@ def parse_tick_flags(value: str) -> int:
     except ValueError:
         valid = ", ".join(TICK_FLAG_MAP)
         msg = f"Invalid tick flags: '{value}'. Use one of: {valid}, or an integer."
-        raise argparse.ArgumentTypeError(msg) from None
+        raise ValueError(msg) from None
 
 
-def _fetch_rates(
-    client: Mt5DataClient,
-    args: argparse.Namespace,
-) -> pd.DataFrame:
-    command: str = args.command
-    if command == "rates-from":
-        return client.copy_rates_from_as_df(
-            symbol=args.symbol,
-            timeframe=args.timeframe,
-            date_from=args.date_from,
-            count=args.count,
-        )
-    if command == "rates-from-pos":
-        return client.copy_rates_from_pos_as_df(
-            symbol=args.symbol,
-            timeframe=args.timeframe,
-            start_pos=args.start_pos,
-            count=args.count,
-        )
-    return client.copy_rates_range_as_df(
-        symbol=args.symbol,
-        timeframe=args.timeframe,
-        date_from=args.date_from,
-        date_to=args.date_to,
-    )
+# ---------------------------------------------------------------------------
+# Typer application
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(
+    name="pdmt5",
+    help="Export MetaTrader5 data to CSV, JSON, Parquet, or SQLite3.",
+)
 
 
-def _fetch_ticks(
-    client: Mt5DataClient,
-    args: argparse.Namespace,
-) -> pd.DataFrame:
-    if args.command == "ticks-from":
-        return client.copy_ticks_from_as_df(
-            symbol=args.symbol,
-            date_from=args.date_from,
-            count=args.count,
-            flags=args.flags,
-        )
-    return client.copy_ticks_range_as_df(
-        symbol=args.symbol,
-        date_from=args.date_from,
-        date_to=args.date_to,
-        flags=args.flags,
-    )
+def _get_export_context(ctx: typer.Context) -> _ExportContext:
+    return cast("_ExportContext", ctx.obj)
 
 
-def _fetch_info(
-    client: Mt5DataClient,
-    args: argparse.Namespace,
-) -> pd.DataFrame:
-    command: str = args.command
-    if command == "account-info":
-        return client.account_info_as_df()
-    if command == "terminal-info":
-        return client.terminal_info_as_df()
-    if command == "symbols":
-        return client.symbols_get_as_df(group=args.group)
-    return client.symbol_info_as_df(symbol=args.symbol)
-
-
-def _fetch_trading(
-    client: Mt5DataClient,
-    args: argparse.Namespace,
-) -> pd.DataFrame:
-    command: str = args.command
-    if command == "orders":
-        return client.orders_get_as_df(
-            symbol=args.symbol,
-            group=args.group,
-            ticket=args.ticket,
-        )
-    if command == "positions":
-        return client.positions_get_as_df(
-            symbol=args.symbol,
-            group=args.group,
-            ticket=args.ticket,
-        )
-    if command == "history-orders":
-        return client.history_orders_get_as_df(
-            date_from=args.date_from,
-            date_to=args.date_to,
-            group=args.group,
-            symbol=args.symbol,
-            ticket=args.ticket,
-            position=args.position,
-        )
-    return client.history_deals_get_as_df(
-        date_from=args.date_from,
-        date_to=args.date_to,
-        group=args.group,
-        symbol=args.symbol,
-        ticket=args.ticket,
-        position=args.position,
-    )
-
-
-_RATES_COMMANDS = frozenset({"rates-from", "rates-from-pos", "rates-range"})
-_TICKS_COMMANDS = frozenset({"ticks-from", "ticks-range"})
-_INFO_COMMANDS = frozenset({"account-info", "terminal-info", "symbols", "symbol-info"})
-_TRADING_COMMANDS = frozenset({
-    "orders",
-    "positions",
-    "history-orders",
-    "history-deals",
-})
-
-
-def fetch_data(
-    client: Mt5DataClient,
-    args: argparse.Namespace,
-) -> pd.DataFrame:
-    """Fetch data from MetaTrader5 based on the CLI subcommand.
+def _execute_export(
+    ctx: typer.Context,
+    fetch_fn: Callable[[Mt5DataClient], pd.DataFrame],
+) -> None:
+    """Execute the common connect-fetch-export-shutdown workflow.
 
     Args:
-        client: MetaTrader5 data client.
-        args: Parsed command-line arguments.
-
-    Returns:
-        DataFrame with the fetched data.
-
-    Raises:
-        ValueError: If the command is unknown.
+        ctx: Typer context carrying shared options.
+        fetch_fn: Callable that receives a connected client and returns a
+            DataFrame.
     """
-    command: str = args.command
-    if command in _RATES_COMMANDS:
-        return _fetch_rates(client, args)
-    if command in _TICKS_COMMANDS:
-        return _fetch_ticks(client, args)
-    if command in _INFO_COMMANDS:
-        return _fetch_info(client, args)
-    if command in _TRADING_COMMANDS:
-        return _fetch_trading(client, args)
-    msg = f"Unknown command: {command}"
-    raise ValueError(msg)
-
-
-def _add_connection_args(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("connection")
-    group.add_argument("--login", type=int, default=None, help="trading account login")
-    group.add_argument("--password", default=None, help="trading account password")
-    group.add_argument("--server", default=None, help="trading server name")
-    group.add_argument(
-        "--path", default=None, help="path to MetaTrader5 terminal EXE file"
-    )
-    group.add_argument(
-        "--timeout", type=int, default=None, help="connection timeout in milliseconds"
-    )
-
-
-def _add_output_args(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("output")
-    group.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        required=True,
-        help="output file path",
-    )
-    group.add_argument(
-        "-f",
-        "--format",
-        choices=("csv", "json", "parquet", "sqlite3"),
-        default=None,
-        help="output format (auto-detected from file extension if omitted)",
-    )
-    group.add_argument(
-        "--table",
-        default="data",
-        help="table name for SQLite3 output (default: data)",
-    )
-
-
-def _add_symbol_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--symbol", required=True, help="symbol name (e.g., EURUSD)")
-
-
-def _add_timeframe_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--timeframe",
-        type=parse_timeframe,
-        required=True,
-        help="timeframe (e.g., M1, M5, H1, H4, D1, W1, MN1, or integer)",
-    )
-
-
-def _add_date_from_arg(
-    parser: argparse.ArgumentParser,
-    required: bool = True,
-) -> None:
-    parser.add_argument(
-        "--date-from",
-        type=parse_datetime,
-        required=required,
-        default=None,
-        help="start date in ISO 8601 format (e.g., 2024-01-01)",
-    )
-
-
-def _add_date_to_arg(
-    parser: argparse.ArgumentParser,
-    required: bool = True,
-) -> None:
-    parser.add_argument(
-        "--date-to",
-        type=parse_datetime,
-        required=required,
-        default=None,
-        help="end date in ISO 8601 format (e.g., 2024-02-01)",
-    )
-
-
-def _add_count_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--count", type=int, required=True, help="number of records to retrieve"
-    )
-
-
-def _add_flags_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--flags",
-        type=parse_tick_flags,
-        required=True,
-        help="tick copy flags (ALL, INFO, TRADE, or integer)",
-    )
-
-
-def _add_filter_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--symbol", default=None, help="symbol filter")
-    parser.add_argument("--group", default=None, help="group filter")
-    parser.add_argument("--ticket", type=int, default=None, help="ticket filter")
-
-
-def _add_history_args(parser: argparse.ArgumentParser) -> None:
-    _add_date_from_arg(parser, required=False)
-    _add_date_to_arg(parser, required=False)
-    parser.add_argument("--group", default=None, help="group filter")
-    parser.add_argument("--symbol", default=None, help="symbol filter")
-    parser.add_argument("--ticket", type=int, default=None, help="order ticket")
-    parser.add_argument("--position", type=int, default=None, help="position ticket")
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    """Build the argument parser for the CLI.
-
-    Returns:
-        Configured argument parser.
-    """
-    parser = argparse.ArgumentParser(
-        prog="pdmt5",
-        description="Export MetaTrader5 data to CSV, JSON, Parquet, or SQLite3.",
-    )
-    _add_connection_args(parser)
-    _add_output_args(parser)
-    parser.add_argument(
-        "--log-level",
-        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
-        default="WARNING",
-        help="logging level (default: WARNING)",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    # rates-from
-    p = subparsers.add_parser("rates-from", help="export rates from a start date")
-    _add_symbol_arg(p)
-    _add_timeframe_arg(p)
-    _add_date_from_arg(p)
-    _add_count_arg(p)
-
-    # rates-from-pos
-    p = subparsers.add_parser(
-        "rates-from-pos", help="export rates from a start position"
-    )
-    _add_symbol_arg(p)
-    _add_timeframe_arg(p)
-    p.add_argument(
-        "--start-pos", type=int, required=True, help="start position (0 = current bar)"
-    )
-    _add_count_arg(p)
-
-    # rates-range
-    p = subparsers.add_parser("rates-range", help="export rates for a date range")
-    _add_symbol_arg(p)
-    _add_timeframe_arg(p)
-    _add_date_from_arg(p)
-    _add_date_to_arg(p)
-
-    # ticks-from
-    p = subparsers.add_parser("ticks-from", help="export ticks from a start date")
-    _add_symbol_arg(p)
-    _add_date_from_arg(p)
-    _add_count_arg(p)
-    _add_flags_arg(p)
-
-    # ticks-range
-    p = subparsers.add_parser("ticks-range", help="export ticks for a date range")
-    _add_symbol_arg(p)
-    _add_date_from_arg(p)
-    _add_date_to_arg(p)
-    _add_flags_arg(p)
-
-    # account-info
-    subparsers.add_parser("account-info", help="export account information")
-
-    # terminal-info
-    subparsers.add_parser("terminal-info", help="export terminal information")
-
-    # symbols
-    p = subparsers.add_parser("symbols", help="export symbol list")
-    p.add_argument("--group", default=None, help="symbol group filter (e.g., *USD*)")
-
-    # symbol-info
-    p = subparsers.add_parser("symbol-info", help="export symbol details")
-    _add_symbol_arg(p)
-
-    # orders
-    p = subparsers.add_parser("orders", help="export active orders")
-    _add_filter_args(p)
-
-    # positions
-    p = subparsers.add_parser("positions", help="export open positions")
-    _add_filter_args(p)
-
-    # history-orders
-    p = subparsers.add_parser("history-orders", help="export historical orders")
-    _add_history_args(p)
-
-    # history-deals
-    p = subparsers.add_parser("history-deals", help="export historical deals")
-    _add_history_args(p)
-
-    return parser
-
-
-def main(argv: Sequence[str] | None = None) -> None:
-    """Run the pdmt5 CLI.
-
-    Args:
-        argv: Command-line arguments (defaults to sys.argv[1:]).
-    """
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-    logging.basicConfig(level=getattr(logging, args.log_level))
-    output_path: Path = args.output
-    try:
-        output_format = detect_format(output_path, args.format)
-    except ValueError as e:
-        parser.error(str(e))
-    config = Mt5Config(
-        path=args.path,
-        login=args.login,
-        password=args.password,
-        server=args.server,
-        timeout=args.timeout,
-    )
-    client = Mt5DataClient(config=config)
+    export_ctx = _get_export_context(ctx)
+    client = Mt5DataClient(config=export_ctx.config)
     client.initialize_and_login_mt5()
     try:
-        df = fetch_data(client, args)
+        df = fetch_fn(client)
         export_dataframe(
             df=df,
-            output_path=output_path,
-            output_format=output_format,
-            table_name=args.table,
+            output_path=export_ctx.output,
+            output_format=export_ctx.output_format,
+            table_name=export_ctx.table,
         )
-        logger.info("Exported %d rows to %s (%s)", len(df), output_path, output_format)
+        logger.info(
+            "Exported %d rows to %s (%s)",
+            len(df),
+            export_ctx.output,
+            export_ctx.output_format,
+        )
     finally:
         client.shutdown()
+
+
+@app.callback()
+def _callback(  # pyright: ignore[reportUnusedFunction]
+    ctx: typer.Context,
+    output: Annotated[
+        Path,
+        typer.Option("--output", "-o", help="Output file path."),
+    ],
+    fmt: Annotated[
+        OutputFormat | None,
+        typer.Option(
+            "--format",
+            "-f",
+            help="Output format (auto-detected from extension if omitted).",
+        ),
+    ] = None,
+    table: Annotated[
+        str,
+        typer.Option(help="Table name for SQLite3 output."),
+    ] = "data",
+    login: Annotated[
+        int | None,
+        typer.Option(help="Trading account login."),
+    ] = None,
+    password: Annotated[
+        str | None,
+        typer.Option(help="Trading account password."),
+    ] = None,
+    server: Annotated[
+        str | None,
+        typer.Option(help="Trading server name."),
+    ] = None,
+    path: Annotated[
+        str | None,
+        typer.Option(help="Path to MetaTrader5 terminal EXE file."),
+    ] = None,
+    timeout: Annotated[
+        int | None,
+        typer.Option(help="Connection timeout in milliseconds."),
+    ] = None,
+    log_level: Annotated[
+        LogLevel,
+        typer.Option("--log-level", help="Logging level."),
+    ] = LogLevel.WARNING,
+) -> None:
+    """Configure shared options for all export commands.
+
+    Raises:
+        typer.BadParameter: If the output format cannot be determined.
+    """
+    logging.basicConfig(level=getattr(logging, log_level.value))
+    try:
+        output_format = detect_format(
+            output,
+            explicit_format=fmt.value if fmt is not None else None,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    ctx.obj = _ExportContext(
+        output=output,
+        output_format=output_format,
+        table=table,
+        config=Mt5Config(
+            path=path,
+            login=login,
+            password=password,
+            server=server,
+            timeout=timeout,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def rates_from(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+    timeframe: Annotated[
+        int,
+        typer.Option(
+            click_type=TIMEFRAME_TYPE,
+            help="Timeframe (e.g., M1, H1, D1, or integer).",
+        ),
+    ],
+    date_from: Annotated[
+        datetime,
+        typer.Option(
+            click_type=DATETIME_TYPE,
+            help="Start date in ISO 8601 format.",
+        ),
+    ],
+    count: Annotated[int, typer.Option(help="Number of records.")],
+) -> None:
+    """Export rates from a start date."""
+    _execute_export(
+        ctx,
+        lambda c: c.copy_rates_from_as_df(
+            symbol=symbol,
+            timeframe=timeframe,
+            date_from=date_from,
+            count=count,
+        ),
+    )
+
+
+@app.command()
+def rates_from_pos(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+    timeframe: Annotated[
+        int,
+        typer.Option(
+            click_type=TIMEFRAME_TYPE,
+            help="Timeframe.",
+        ),
+    ],
+    start_pos: Annotated[int, typer.Option(help="Start position (0 = current bar).")],
+    count: Annotated[int, typer.Option(help="Number of records.")],
+) -> None:
+    """Export rates from a start position."""
+    _execute_export(
+        ctx,
+        lambda c: c.copy_rates_from_pos_as_df(
+            symbol=symbol,
+            timeframe=timeframe,
+            start_pos=start_pos,
+            count=count,
+        ),
+    )
+
+
+@app.command()
+def rates_range(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+    timeframe: Annotated[
+        int,
+        typer.Option(
+            click_type=TIMEFRAME_TYPE,
+            help="Timeframe.",
+        ),
+    ],
+    date_from: Annotated[
+        datetime,
+        typer.Option(click_type=DATETIME_TYPE, help="Start date."),
+    ],
+    date_to: Annotated[
+        datetime,
+        typer.Option(click_type=DATETIME_TYPE, help="End date."),
+    ],
+) -> None:
+    """Export rates for a date range."""
+    _execute_export(
+        ctx,
+        lambda c: c.copy_rates_range_as_df(
+            symbol=symbol,
+            timeframe=timeframe,
+            date_from=date_from,
+            date_to=date_to,
+        ),
+    )
+
+
+@app.command()
+def ticks_from(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+    date_from: Annotated[
+        datetime,
+        typer.Option(click_type=DATETIME_TYPE, help="Start date."),
+    ],
+    count: Annotated[int, typer.Option(help="Number of ticks.")],
+    flags: Annotated[
+        int,
+        typer.Option(
+            click_type=TICK_FLAGS_TYPE,
+            help="Tick flags (ALL, INFO, TRADE, or integer).",
+        ),
+    ],
+) -> None:
+    """Export ticks from a start date."""
+    _execute_export(
+        ctx,
+        lambda c: c.copy_ticks_from_as_df(
+            symbol=symbol,
+            date_from=date_from,
+            count=count,
+            flags=flags,
+        ),
+    )
+
+
+@app.command()
+def ticks_range(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+    date_from: Annotated[
+        datetime,
+        typer.Option(click_type=DATETIME_TYPE, help="Start date."),
+    ],
+    date_to: Annotated[
+        datetime,
+        typer.Option(click_type=DATETIME_TYPE, help="End date."),
+    ],
+    flags: Annotated[
+        int,
+        typer.Option(click_type=TICK_FLAGS_TYPE, help="Tick flags."),
+    ],
+) -> None:
+    """Export ticks for a date range."""
+    _execute_export(
+        ctx,
+        lambda c: c.copy_ticks_range_as_df(
+            symbol=symbol,
+            date_from=date_from,
+            date_to=date_to,
+            flags=flags,
+        ),
+    )
+
+
+@app.command()
+def account_info(ctx: typer.Context) -> None:
+    """Export account information."""
+    _execute_export(ctx, lambda c: c.account_info_as_df())
+
+
+@app.command()
+def terminal_info(ctx: typer.Context) -> None:
+    """Export terminal information."""
+    _execute_export(ctx, lambda c: c.terminal_info_as_df())
+
+
+@app.command()
+def symbols(
+    ctx: typer.Context,
+    group: Annotated[
+        str | None,
+        typer.Option(help="Symbol group filter (e.g., *USD*)."),
+    ] = None,
+) -> None:
+    """Export symbol list."""
+    _execute_export(
+        ctx,
+        lambda c: c.symbols_get_as_df(group=group),
+    )
+
+
+@app.command()
+def symbol_info(
+    ctx: typer.Context,
+    symbol: Annotated[str, typer.Option(help="Symbol name.")],
+) -> None:
+    """Export symbol details."""
+    _execute_export(
+        ctx,
+        lambda c: c.symbol_info_as_df(symbol=symbol),
+    )
+
+
+@app.command()
+def orders(
+    ctx: typer.Context,
+    symbol: Annotated[str | None, typer.Option(help="Symbol filter.")] = None,
+    group: Annotated[str | None, typer.Option(help="Group filter.")] = None,
+    ticket: Annotated[int | None, typer.Option(help="Ticket filter.")] = None,
+) -> None:
+    """Export active orders."""
+    _execute_export(
+        ctx,
+        lambda c: c.orders_get_as_df(
+            symbol=symbol,
+            group=group,
+            ticket=ticket,
+        ),
+    )
+
+
+@app.command()
+def positions(
+    ctx: typer.Context,
+    symbol: Annotated[str | None, typer.Option(help="Symbol filter.")] = None,
+    group: Annotated[str | None, typer.Option(help="Group filter.")] = None,
+    ticket: Annotated[int | None, typer.Option(help="Ticket filter.")] = None,
+) -> None:
+    """Export open positions."""
+    _execute_export(
+        ctx,
+        lambda c: c.positions_get_as_df(
+            symbol=symbol,
+            group=group,
+            ticket=ticket,
+        ),
+    )
+
+
+@app.command()
+def history_orders(
+    ctx: typer.Context,
+    date_from: Annotated[
+        datetime | None,
+        typer.Option(click_type=DATETIME_TYPE, help="Start date."),
+    ] = None,
+    date_to: Annotated[
+        datetime | None,
+        typer.Option(click_type=DATETIME_TYPE, help="End date."),
+    ] = None,
+    group: Annotated[str | None, typer.Option(help="Group filter.")] = None,
+    symbol: Annotated[str | None, typer.Option(help="Symbol filter.")] = None,
+    ticket: Annotated[int | None, typer.Option(help="Order ticket.")] = None,
+    position: Annotated[int | None, typer.Option(help="Position ticket.")] = None,
+) -> None:
+    """Export historical orders."""
+    _execute_export(
+        ctx,
+        lambda c: c.history_orders_get_as_df(
+            date_from=date_from,
+            date_to=date_to,
+            group=group,
+            symbol=symbol,
+            ticket=ticket,
+            position=position,
+        ),
+    )
+
+
+@app.command()
+def history_deals(
+    ctx: typer.Context,
+    date_from: Annotated[
+        datetime | None,
+        typer.Option(click_type=DATETIME_TYPE, help="Start date."),
+    ] = None,
+    date_to: Annotated[
+        datetime | None,
+        typer.Option(click_type=DATETIME_TYPE, help="End date."),
+    ] = None,
+    group: Annotated[str | None, typer.Option(help="Group filter.")] = None,
+    symbol: Annotated[str | None, typer.Option(help="Symbol filter.")] = None,
+    ticket: Annotated[int | None, typer.Option(help="Order ticket.")] = None,
+    position: Annotated[int | None, typer.Option(help="Position ticket.")] = None,
+) -> None:
+    """Export historical deals."""
+    _execute_export(
+        ctx,
+        lambda c: c.history_deals_get_as_df(
+            date_from=date_from,
+            date_to=date_to,
+            group=group,
+            symbol=symbol,
+            ticket=ticket,
+            position=position,
+        ),
+    )
+
+
+def main() -> None:
+    """Run the pdmt5 CLI."""
+    app()

--- a/pdmt5/cli.py
+++ b/pdmt5/cli.py
@@ -1,0 +1,561 @@
+"""Command-line interface for pdmt5 data export."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .dataframe import Mt5Config, Mt5DataClient
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+TIMEFRAME_MAP: dict[str, int] = {
+    "M1": 1,
+    "M2": 2,
+    "M3": 3,
+    "M4": 4,
+    "M5": 5,
+    "M6": 6,
+    "M10": 10,
+    "M12": 12,
+    "M15": 15,
+    "M20": 20,
+    "M30": 30,
+    "H1": 16385,
+    "H2": 16386,
+    "H3": 16387,
+    "H4": 16388,
+    "H6": 16390,
+    "H8": 16392,
+    "H12": 16396,
+    "D1": 16408,
+    "W1": 32769,
+    "MN1": 49153,
+}
+
+TICK_FLAG_MAP: dict[str, int] = {
+    "ALL": 1,
+    "INFO": 2,
+    "TRADE": 4,
+}
+
+_FORMAT_EXTENSIONS: dict[str, str] = {
+    ".csv": "csv",
+    ".json": "json",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+    ".db": "sqlite3",
+    ".sqlite": "sqlite3",
+    ".sqlite3": "sqlite3",
+}
+
+
+def detect_format(
+    output_path: Path,
+    explicit_format: str | None = None,
+) -> str:
+    """Detect the output format from a file extension or explicit format string.
+
+    Args:
+        output_path: Path to the output file.
+        explicit_format: Explicitly specified format, if any.
+
+    Returns:
+        The detected format string.
+
+    Raises:
+        ValueError: If the format cannot be determined.
+    """
+    if explicit_format is not None:
+        return explicit_format
+    suffix = output_path.suffix.lower()
+    if suffix in _FORMAT_EXTENSIONS:
+        return _FORMAT_EXTENSIONS[suffix]
+    msg = (
+        f"Cannot detect format from extension '{suffix}'."
+        " Use --format to specify the output format."
+    )
+    raise ValueError(msg)
+
+
+def export_dataframe(
+    df: pd.DataFrame,
+    output_path: Path,
+    output_format: str,
+    table_name: str = "data",
+) -> None:
+    """Export a pandas DataFrame to the specified file format.
+
+    Args:
+        df: DataFrame to export.
+        output_path: Path to the output file.
+        output_format: Output format (csv, json, parquet, or sqlite3).
+        table_name: Table name for SQLite3 output.
+
+    Raises:
+        ValueError: If the output format is not supported.
+    """
+    if output_format == "csv":
+        df.to_csv(output_path, index=False)
+    elif output_format == "json":
+        df.to_json(output_path, orient="records", date_format="iso", indent=2)
+    elif output_format == "parquet":
+        df.to_parquet(output_path, index=False)
+    elif output_format == "sqlite3":
+        with sqlite3.connect(output_path) as conn:
+            df.to_sql(  # type: ignore[reportUnknownMemberType]
+                table_name,
+                conn,
+                if_exists="replace",
+                index=False,
+            )
+    else:
+        msg = f"Unsupported output format: {output_format}"
+        raise ValueError(msg)
+
+
+def parse_datetime(value: str) -> datetime:
+    """Parse an ISO 8601 datetime string to a timezone-aware datetime.
+
+    Args:
+        value: ISO 8601 datetime string (e.g., '2024-01-01' or
+            '2024-01-01T12:00:00+00:00').
+
+    Returns:
+        Parsed datetime with UTC timezone if no timezone is specified.
+
+    Raises:
+        argparse.ArgumentTypeError: If the string cannot be parsed.
+    """
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        msg = f"Invalid datetime format: '{value}'. Use ISO 8601 format."
+        raise argparse.ArgumentTypeError(msg) from None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def parse_timeframe(value: str) -> int:
+    """Parse a timeframe string or integer value.
+
+    Args:
+        value: Timeframe name (e.g., 'M1', 'H1', 'D1') or integer value.
+
+    Returns:
+        Integer timeframe value.
+
+    Raises:
+        argparse.ArgumentTypeError: If the timeframe is invalid.
+    """
+    upper = value.upper()
+    if upper in TIMEFRAME_MAP:
+        return TIMEFRAME_MAP[upper]
+    try:
+        return int(value)
+    except ValueError:
+        valid = ", ".join(TIMEFRAME_MAP)
+        msg = f"Invalid timeframe: '{value}'. Use one of: {valid}, or an integer."
+        raise argparse.ArgumentTypeError(msg) from None
+
+
+def parse_tick_flags(value: str) -> int:
+    """Parse tick flags string or integer value.
+
+    Args:
+        value: Tick flag name (ALL, INFO, TRADE) or integer value.
+
+    Returns:
+        Integer tick flag value.
+
+    Raises:
+        argparse.ArgumentTypeError: If the flag is invalid.
+    """
+    upper = value.upper()
+    if upper in TICK_FLAG_MAP:
+        return TICK_FLAG_MAP[upper]
+    try:
+        return int(value)
+    except ValueError:
+        valid = ", ".join(TICK_FLAG_MAP)
+        msg = f"Invalid tick flags: '{value}'. Use one of: {valid}, or an integer."
+        raise argparse.ArgumentTypeError(msg) from None
+
+
+def _fetch_rates(
+    client: Mt5DataClient,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    command: str = args.command
+    if command == "rates-from":
+        return client.copy_rates_from_as_df(
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            date_from=args.date_from,
+            count=args.count,
+        )
+    if command == "rates-from-pos":
+        return client.copy_rates_from_pos_as_df(
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            start_pos=args.start_pos,
+            count=args.count,
+        )
+    return client.copy_rates_range_as_df(
+        symbol=args.symbol,
+        timeframe=args.timeframe,
+        date_from=args.date_from,
+        date_to=args.date_to,
+    )
+
+
+def _fetch_ticks(
+    client: Mt5DataClient,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    if args.command == "ticks-from":
+        return client.copy_ticks_from_as_df(
+            symbol=args.symbol,
+            date_from=args.date_from,
+            count=args.count,
+            flags=args.flags,
+        )
+    return client.copy_ticks_range_as_df(
+        symbol=args.symbol,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        flags=args.flags,
+    )
+
+
+def _fetch_info(
+    client: Mt5DataClient,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    command: str = args.command
+    if command == "account-info":
+        return client.account_info_as_df()
+    if command == "terminal-info":
+        return client.terminal_info_as_df()
+    if command == "symbols":
+        return client.symbols_get_as_df(group=args.group)
+    return client.symbol_info_as_df(symbol=args.symbol)
+
+
+def _fetch_trading(
+    client: Mt5DataClient,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    command: str = args.command
+    if command == "orders":
+        return client.orders_get_as_df(
+            symbol=args.symbol,
+            group=args.group,
+            ticket=args.ticket,
+        )
+    if command == "positions":
+        return client.positions_get_as_df(
+            symbol=args.symbol,
+            group=args.group,
+            ticket=args.ticket,
+        )
+    if command == "history-orders":
+        return client.history_orders_get_as_df(
+            date_from=args.date_from,
+            date_to=args.date_to,
+            group=args.group,
+            symbol=args.symbol,
+            ticket=args.ticket,
+            position=args.position,
+        )
+    return client.history_deals_get_as_df(
+        date_from=args.date_from,
+        date_to=args.date_to,
+        group=args.group,
+        symbol=args.symbol,
+        ticket=args.ticket,
+        position=args.position,
+    )
+
+
+_RATES_COMMANDS = frozenset({"rates-from", "rates-from-pos", "rates-range"})
+_TICKS_COMMANDS = frozenset({"ticks-from", "ticks-range"})
+_INFO_COMMANDS = frozenset({"account-info", "terminal-info", "symbols", "symbol-info"})
+_TRADING_COMMANDS = frozenset({
+    "orders",
+    "positions",
+    "history-orders",
+    "history-deals",
+})
+
+
+def fetch_data(
+    client: Mt5DataClient,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    """Fetch data from MetaTrader5 based on the CLI subcommand.
+
+    Args:
+        client: MetaTrader5 data client.
+        args: Parsed command-line arguments.
+
+    Returns:
+        DataFrame with the fetched data.
+
+    Raises:
+        ValueError: If the command is unknown.
+    """
+    command: str = args.command
+    if command in _RATES_COMMANDS:
+        return _fetch_rates(client, args)
+    if command in _TICKS_COMMANDS:
+        return _fetch_ticks(client, args)
+    if command in _INFO_COMMANDS:
+        return _fetch_info(client, args)
+    if command in _TRADING_COMMANDS:
+        return _fetch_trading(client, args)
+    msg = f"Unknown command: {command}"
+    raise ValueError(msg)
+
+
+def _add_connection_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("connection")
+    group.add_argument("--login", type=int, default=None, help="trading account login")
+    group.add_argument("--password", default=None, help="trading account password")
+    group.add_argument("--server", default=None, help="trading server name")
+    group.add_argument(
+        "--path", default=None, help="path to MetaTrader5 terminal EXE file"
+    )
+    group.add_argument(
+        "--timeout", type=int, default=None, help="connection timeout in milliseconds"
+    )
+
+
+def _add_output_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("output")
+    group.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        required=True,
+        help="output file path",
+    )
+    group.add_argument(
+        "-f",
+        "--format",
+        choices=("csv", "json", "parquet", "sqlite3"),
+        default=None,
+        help="output format (auto-detected from file extension if omitted)",
+    )
+    group.add_argument(
+        "--table",
+        default="data",
+        help="table name for SQLite3 output (default: data)",
+    )
+
+
+def _add_symbol_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--symbol", required=True, help="symbol name (e.g., EURUSD)")
+
+
+def _add_timeframe_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--timeframe",
+        type=parse_timeframe,
+        required=True,
+        help="timeframe (e.g., M1, M5, H1, H4, D1, W1, MN1, or integer)",
+    )
+
+
+def _add_date_from_arg(
+    parser: argparse.ArgumentParser,
+    required: bool = True,
+) -> None:
+    parser.add_argument(
+        "--date-from",
+        type=parse_datetime,
+        required=required,
+        default=None,
+        help="start date in ISO 8601 format (e.g., 2024-01-01)",
+    )
+
+
+def _add_date_to_arg(
+    parser: argparse.ArgumentParser,
+    required: bool = True,
+) -> None:
+    parser.add_argument(
+        "--date-to",
+        type=parse_datetime,
+        required=required,
+        default=None,
+        help="end date in ISO 8601 format (e.g., 2024-02-01)",
+    )
+
+
+def _add_count_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--count", type=int, required=True, help="number of records to retrieve"
+    )
+
+
+def _add_flags_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--flags",
+        type=parse_tick_flags,
+        required=True,
+        help="tick copy flags (ALL, INFO, TRADE, or integer)",
+    )
+
+
+def _add_filter_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--symbol", default=None, help="symbol filter")
+    parser.add_argument("--group", default=None, help="group filter")
+    parser.add_argument("--ticket", type=int, default=None, help="ticket filter")
+
+
+def _add_history_args(parser: argparse.ArgumentParser) -> None:
+    _add_date_from_arg(parser, required=False)
+    _add_date_to_arg(parser, required=False)
+    parser.add_argument("--group", default=None, help="group filter")
+    parser.add_argument("--symbol", default=None, help="symbol filter")
+    parser.add_argument("--ticket", type=int, default=None, help="order ticket")
+    parser.add_argument("--position", type=int, default=None, help="position ticket")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the CLI.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="pdmt5",
+        description="Export MetaTrader5 data to CSV, JSON, Parquet, or SQLite3.",
+    )
+    _add_connection_args(parser)
+    _add_output_args(parser)
+    parser.add_argument(
+        "--log-level",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+        default="WARNING",
+        help="logging level (default: WARNING)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # rates-from
+    p = subparsers.add_parser("rates-from", help="export rates from a start date")
+    _add_symbol_arg(p)
+    _add_timeframe_arg(p)
+    _add_date_from_arg(p)
+    _add_count_arg(p)
+
+    # rates-from-pos
+    p = subparsers.add_parser(
+        "rates-from-pos", help="export rates from a start position"
+    )
+    _add_symbol_arg(p)
+    _add_timeframe_arg(p)
+    p.add_argument(
+        "--start-pos", type=int, required=True, help="start position (0 = current bar)"
+    )
+    _add_count_arg(p)
+
+    # rates-range
+    p = subparsers.add_parser("rates-range", help="export rates for a date range")
+    _add_symbol_arg(p)
+    _add_timeframe_arg(p)
+    _add_date_from_arg(p)
+    _add_date_to_arg(p)
+
+    # ticks-from
+    p = subparsers.add_parser("ticks-from", help="export ticks from a start date")
+    _add_symbol_arg(p)
+    _add_date_from_arg(p)
+    _add_count_arg(p)
+    _add_flags_arg(p)
+
+    # ticks-range
+    p = subparsers.add_parser("ticks-range", help="export ticks for a date range")
+    _add_symbol_arg(p)
+    _add_date_from_arg(p)
+    _add_date_to_arg(p)
+    _add_flags_arg(p)
+
+    # account-info
+    subparsers.add_parser("account-info", help="export account information")
+
+    # terminal-info
+    subparsers.add_parser("terminal-info", help="export terminal information")
+
+    # symbols
+    p = subparsers.add_parser("symbols", help="export symbol list")
+    p.add_argument("--group", default=None, help="symbol group filter (e.g., *USD*)")
+
+    # symbol-info
+    p = subparsers.add_parser("symbol-info", help="export symbol details")
+    _add_symbol_arg(p)
+
+    # orders
+    p = subparsers.add_parser("orders", help="export active orders")
+    _add_filter_args(p)
+
+    # positions
+    p = subparsers.add_parser("positions", help="export open positions")
+    _add_filter_args(p)
+
+    # history-orders
+    p = subparsers.add_parser("history-orders", help="export historical orders")
+    _add_history_args(p)
+
+    # history-deals
+    p = subparsers.add_parser("history-deals", help="export historical deals")
+    _add_history_args(p)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the pdmt5 CLI.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv[1:]).
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    output_path: Path = args.output
+    try:
+        output_format = detect_format(output_path, args.format)
+    except ValueError as e:
+        parser.error(str(e))
+    config = Mt5Config(
+        path=args.path,
+        login=args.login,
+        password=args.password,
+        server=args.server,
+        timeout=args.timeout,
+    )
+    client = Mt5DataClient(config=config)
+    client.initialize_and_login_mt5()
+    try:
+        df = fetch_data(client, args)
+        export_dataframe(
+            df=df,
+            output_path=output_path,
+            output_format=output_format,
+            table_name=args.table,
+        )
+        logger.info("Exported %d rows to %s (%s)", len(df), output_path, output_format)
+    finally:
+        client.shutdown()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "MetaTrader5 >= 5.0.4424; sys_platform == 'win32'",
   "pandas >= 2.2.2",
   "pydantic >= 2.9.0",
+  "typer >= 0.12.0",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
   "Topic :: Office/Business :: Financial :: Investment",
 ]
 
+[project.scripts]
+pdmt5 = "pdmt5.cli:main"
+
 [project.urls]
 Repository = "https://github.com/dceoy/pdmt5.git"
 
@@ -172,6 +175,7 @@ minversion = "6.0"
 source = ["pdmt5"]
 omit = [
   "**/__init__.py",
+  "**/__main__.py",
   "tests/**",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">= 3.11, < 3.14"
 dependencies = [
   "MetaTrader5 >= 5.0.4424; sys_platform == 'win32'",
   "pandas >= 2.2.2",
+  "pyarrow >= 19.0.0",
   "pydantic >= 2.9.0",
   "typer >= 0.12.0",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,33 +2,43 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 import sqlite3
 from datetime import UTC, datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 from pytest_mock import MockerFixture  # noqa: TC002
+from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from pdmt5.cli import (
+    DATETIME_TYPE,
     TICK_FLAG_MAP,
+    TICK_FLAGS_TYPE,
     TIMEFRAME_MAP,
-    _build_parser,  # type: ignore[reportPrivateUsage]
-    _fetch_info,  # type: ignore[reportPrivateUsage]
-    _fetch_rates,  # type: ignore[reportPrivateUsage]
-    _fetch_ticks,  # type: ignore[reportPrivateUsage]
-    _fetch_trading,  # type: ignore[reportPrivateUsage]
+    TIMEFRAME_TYPE,
+    _execute_export,  # type: ignore[reportPrivateUsage]
+    _ExportContext,  # type: ignore[reportPrivateUsage]
+    app,
     detect_format,
     export_dataframe,
-    fetch_data,
     main,
     parse_datetime,
     parse_tick_flags,
     parse_timeframe,
 )
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# detect_format
+# ---------------------------------------------------------------------------
 
 
 class TestDetectFormat:
@@ -68,6 +78,11 @@ class TestDetectFormat:
         """Test that unknown extension raises ValueError."""
         with pytest.raises(ValueError, match="Cannot detect format"):
             detect_format(tmp_path / "data.xyz")
+
+
+# ---------------------------------------------------------------------------
+# export_dataframe
+# ---------------------------------------------------------------------------
 
 
 class TestExportDataframe:
@@ -122,6 +137,11 @@ class TestExportDataframe:
             export_dataframe(sample_df, tmp_path / "out.txt", "xml")
 
 
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+
+
 class TestParseDatetime:
     """Tests for parse_datetime."""
 
@@ -136,8 +156,8 @@ class TestParseDatetime:
         assert result == datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
     def test_invalid_format_raises(self) -> None:
-        """Test that invalid format raises ArgumentTypeError."""
-        with pytest.raises(argparse.ArgumentTypeError, match="Invalid datetime"):
+        """Test that invalid format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid datetime"):
             parse_datetime("not-a-date")
 
 
@@ -157,8 +177,8 @@ class TestParseTimeframe:
         assert parse_timeframe("42") == 42
 
     def test_invalid_timeframe_raises(self) -> None:
-        """Test that invalid timeframe raises ArgumentTypeError."""
-        with pytest.raises(argparse.ArgumentTypeError, match="Invalid timeframe"):
+        """Test that invalid timeframe raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid timeframe"):
             parse_timeframe("INVALID")
 
 
@@ -178,9 +198,14 @@ class TestParseTickFlags:
         assert parse_tick_flags("7") == 7
 
     def test_invalid_flag_raises(self) -> None:
-        """Test that invalid flag raises ArgumentTypeError."""
-        with pytest.raises(argparse.ArgumentTypeError, match="Invalid tick flags"):
+        """Test that invalid flag raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid tick flags"):
             parse_tick_flags("INVALID")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
 
 class TestConstants:
@@ -196,14 +221,101 @@ class TestConstants:
         assert set(TICK_FLAG_MAP) == {"ALL", "INFO", "TRADE"}
 
 
-def _make_args(**kwargs: object) -> argparse.Namespace:
-    """Create an argparse.Namespace with given attributes."""
-    return argparse.Namespace(**kwargs)
+# ---------------------------------------------------------------------------
+# Click ParamTypes
+# ---------------------------------------------------------------------------
+
+
+class TestDateTimeType:
+    """Tests for _DateTimeType."""
+
+    def test_convert_string(self) -> None:
+        """Test converting a string to datetime."""
+        result = DATETIME_TYPE.convert("2024-06-15", None, None)
+        assert result == datetime(2024, 6, 15, tzinfo=UTC)
+
+    def test_convert_datetime_passthrough(self) -> None:
+        """Test that datetime values pass through unchanged."""
+        dt = datetime(2024, 1, 1, tzinfo=UTC)
+        assert DATETIME_TYPE.convert(dt, None, None) is dt
+
+    def test_convert_invalid(self) -> None:
+        """Test that invalid values raise BadParameter."""
+        with pytest.raises(Exception, match="Invalid datetime"):
+            DATETIME_TYPE.convert("bad", None, None)
+
+
+class TestTimeframeType:
+    """Tests for _TimeframeType."""
+
+    def test_convert_string(self) -> None:
+        """Test converting a string to timeframe integer."""
+        assert TIMEFRAME_TYPE.convert("H1", None, None) == 16385
+
+    def test_convert_int_passthrough(self) -> None:
+        """Test that integer values pass through unchanged."""
+        assert TIMEFRAME_TYPE.convert(42, None, None) == 42
+
+    def test_convert_invalid(self) -> None:
+        """Test that invalid values raise BadParameter."""
+        with pytest.raises(Exception, match="Invalid timeframe"):
+            TIMEFRAME_TYPE.convert("bad", None, None)
+
+
+class TestTickFlagsType:
+    """Tests for _TickFlagsType."""
+
+    def test_convert_string(self) -> None:
+        """Test converting a string to tick flags integer."""
+        assert TICK_FLAGS_TYPE.convert("ALL", None, None) == 1
+
+    def test_convert_int_passthrough(self) -> None:
+        """Test that integer values pass through unchanged."""
+        assert TICK_FLAGS_TYPE.convert(7, None, None) == 7
+
+    def test_convert_invalid(self) -> None:
+        """Test that invalid values raise BadParameter."""
+        with pytest.raises(Exception, match="Invalid tick flags"):
+            TICK_FLAGS_TYPE.convert("bad", None, None)
+
+
+# ---------------------------------------------------------------------------
+# _execute_export
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExport:
+    """Tests for _execute_export."""
+
+    def test_shutdown_on_error(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that shutdown is called even when fetch raises."""
+        mock_client = MagicMock()
+        mock_client.account_info_as_df.side_effect = RuntimeError("boom")
+        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        ctx = MagicMock()
+        ctx.obj = _ExportContext(
+            output=tmp_path / "out.csv",
+            output_format="csv",
+            table="data",
+            config=MagicMock(),
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            _execute_export(ctx, lambda c: c.account_info_as_df())
+        mock_client.shutdown.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI commands via CliRunner
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def mock_client() -> MagicMock:
-    """Create a mock Mt5DataClient."""
+def mock_client(mocker: MockerFixture) -> MagicMock:
+    """Create and patch a mock Mt5DataClient for CLI tests."""
     client = MagicMock()
     sample_df = pd.DataFrame({"col": [1]})
     client.copy_rates_from_as_df.return_value = sample_df
@@ -219,40 +331,129 @@ def mock_client() -> MagicMock:
     client.positions_get_as_df.return_value = sample_df
     client.history_orders_get_as_df.return_value = sample_df
     client.history_deals_get_as_df.return_value = sample_df
+    mocker.patch("pdmt5.cli.Mt5DataClient", return_value=client)
     return client
 
 
-class TestFetchRates:
-    """Tests for _fetch_rates."""
+class TestCommands:
+    """Tests for all CLI subcommands via CliRunner."""
 
-    def test_rates_from(self, mock_client: MagicMock) -> None:
-        """Test rates-from command dispatches correctly."""
-        dt = datetime(2024, 1, 1, tzinfo=UTC)
-        args = _make_args(
-            command="rates-from",
-            symbol="EURUSD",
-            timeframe=1,
-            date_from=dt,
-            count=100,
+    def test_account_info(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test account-info command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "account-info"],
         )
-        _fetch_rates(mock_client, args)
+        assert result.exit_code == 0, result.output
+        mock_client.account_info_as_df.assert_called_once()
+        assert output.exists()
+
+    def test_terminal_info(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test terminal-info command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "terminal-info"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.terminal_info_as_df.assert_called_once()
+
+    def test_symbols(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test symbols command."""
+        output = tmp_path / "out.json"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "symbols", "--group", "*USD*"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.symbols_get_as_df.assert_called_once_with(
+            group="*USD*",
+        )
+
+    def test_symbol_info(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test symbol-info command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "symbol-info", "--symbol", "EURUSD"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.symbol_info_as_df.assert_called_once_with(
+            symbol="EURUSD",
+        )
+
+    def test_rates_from(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test rates-from command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "rates-from",
+                "--symbol",
+                "EURUSD",
+                "--timeframe",
+                "M1",
+                "--date-from",
+                "2024-01-01",
+                "--count",
+                "100",
+            ],
+        )
+        assert result.exit_code == 0, result.output
         mock_client.copy_rates_from_as_df.assert_called_once_with(
             symbol="EURUSD",
             timeframe=1,
-            date_from=dt,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
             count=100,
         )
 
-    def test_rates_from_pos(self, mock_client: MagicMock) -> None:
-        """Test rates-from-pos command dispatches correctly."""
-        args = _make_args(
-            command="rates-from-pos",
-            symbol="GBPUSD",
-            timeframe=16385,
-            start_pos=0,
-            count=50,
+    def test_rates_from_pos(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test rates-from-pos command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "rates-from-pos",
+                "--symbol",
+                "GBPUSD",
+                "--timeframe",
+                "H1",
+                "--start-pos",
+                "0",
+                "--count",
+                "50",
+            ],
         )
-        _fetch_rates(mock_client, args)
+        assert result.exit_code == 0, result.output
         mock_client.copy_rates_from_pos_as_df.assert_called_once_with(
             symbol="GBPUSD",
             timeframe=16385,
@@ -260,560 +461,291 @@ class TestFetchRates:
             count=50,
         )
 
-    def test_rates_range(self, mock_client: MagicMock) -> None:
-        """Test rates-range command dispatches correctly."""
-        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
-        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
-        args = _make_args(
-            command="rates-range",
-            symbol="USDJPY",
-            timeframe=16408,
-            date_from=dt_from,
-            date_to=dt_to,
+    def test_rates_range(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test rates-range command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "rates-range",
+                "--symbol",
+                "USDJPY",
+                "--timeframe",
+                "D1",
+                "--date-from",
+                "2024-01-01",
+                "--date-to",
+                "2024-02-01",
+            ],
         )
-        _fetch_rates(mock_client, args)
+        assert result.exit_code == 0, result.output
         mock_client.copy_rates_range_as_df.assert_called_once_with(
             symbol="USDJPY",
             timeframe=16408,
-            date_from=dt_from,
-            date_to=dt_to,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
+            date_to=datetime(2024, 2, 1, tzinfo=UTC),
         )
 
-
-class TestFetchTicks:
-    """Tests for _fetch_ticks."""
-
-    def test_ticks_from(self, mock_client: MagicMock) -> None:
-        """Test ticks-from command dispatches correctly."""
-        dt = datetime(2024, 1, 1, tzinfo=UTC)
-        args = _make_args(
-            command="ticks-from",
-            symbol="EURUSD",
-            date_from=dt,
-            count=100,
-            flags=1,
+    def test_ticks_from(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test ticks-from command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "ticks-from",
+                "--symbol",
+                "EURUSD",
+                "--date-from",
+                "2024-01-01",
+                "--count",
+                "100",
+                "--flags",
+                "ALL",
+            ],
         )
-        _fetch_ticks(mock_client, args)
+        assert result.exit_code == 0, result.output
         mock_client.copy_ticks_from_as_df.assert_called_once_with(
             symbol="EURUSD",
-            date_from=dt,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
             count=100,
             flags=1,
         )
 
-    def test_ticks_range(self, mock_client: MagicMock) -> None:
-        """Test ticks-range command dispatches correctly."""
-        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
-        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
-        args = _make_args(
-            command="ticks-range",
-            symbol="EURUSD",
-            date_from=dt_from,
-            date_to=dt_to,
-            flags=2,
+    def test_ticks_range(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test ticks-range command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "ticks-range",
+                "--symbol",
+                "EURUSD",
+                "--date-from",
+                "2024-01-01",
+                "--date-to",
+                "2024-02-01",
+                "--flags",
+                "INFO",
+            ],
         )
-        _fetch_ticks(mock_client, args)
+        assert result.exit_code == 0, result.output
         mock_client.copy_ticks_range_as_df.assert_called_once_with(
             symbol="EURUSD",
-            date_from=dt_from,
-            date_to=dt_to,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
+            date_to=datetime(2024, 2, 1, tzinfo=UTC),
             flags=2,
         )
 
-
-class TestFetchInfo:
-    """Tests for _fetch_info."""
-
-    def test_account_info(self, mock_client: MagicMock) -> None:
-        """Test account-info command dispatches correctly."""
-        args = _make_args(command="account-info")
-        _fetch_info(mock_client, args)
-        mock_client.account_info_as_df.assert_called_once()
-
-    def test_terminal_info(self, mock_client: MagicMock) -> None:
-        """Test terminal-info command dispatches correctly."""
-        args = _make_args(command="terminal-info")
-        _fetch_info(mock_client, args)
-        mock_client.terminal_info_as_df.assert_called_once()
-
-    def test_symbols(self, mock_client: MagicMock) -> None:
-        """Test symbols command dispatches correctly."""
-        args = _make_args(command="symbols", group="*USD*")
-        _fetch_info(mock_client, args)
-        mock_client.symbols_get_as_df.assert_called_once_with(group="*USD*")
-
-    def test_symbol_info(self, mock_client: MagicMock) -> None:
-        """Test symbol-info command dispatches correctly."""
-        args = _make_args(command="symbol-info", symbol="EURUSD")
-        _fetch_info(mock_client, args)
-        mock_client.symbol_info_as_df.assert_called_once_with(symbol="EURUSD")
-
-
-class TestFetchTrading:
-    """Tests for _fetch_trading."""
-
-    def test_orders(self, mock_client: MagicMock) -> None:
-        """Test orders command dispatches correctly."""
-        args = _make_args(
-            command="orders",
-            symbol="EURUSD",
-            group=None,
-            ticket=None,
-        )
-        _fetch_trading(mock_client, args)
-        mock_client.orders_get_as_df.assert_called_once_with(
-            symbol="EURUSD",
-            group=None,
-            ticket=None,
-        )
-
-    def test_positions(self, mock_client: MagicMock) -> None:
-        """Test positions command dispatches correctly."""
-        args = _make_args(
-            command="positions",
-            symbol=None,
-            group="*USD*",
-            ticket=None,
-        )
-        _fetch_trading(mock_client, args)
-        mock_client.positions_get_as_df.assert_called_once_with(
-            symbol=None,
-            group="*USD*",
-            ticket=None,
-        )
-
-    def test_history_orders(self, mock_client: MagicMock) -> None:
-        """Test history-orders command dispatches correctly."""
-        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
-        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
-        args = _make_args(
-            command="history-orders",
-            date_from=dt_from,
-            date_to=dt_to,
-            group=None,
-            symbol="EURUSD",
-            ticket=None,
-            position=None,
-        )
-        _fetch_trading(mock_client, args)
-        mock_client.history_orders_get_as_df.assert_called_once_with(
-            date_from=dt_from,
-            date_to=dt_to,
-            group=None,
-            symbol="EURUSD",
-            ticket=None,
-            position=None,
-        )
-
-    def test_history_deals(self, mock_client: MagicMock) -> None:
-        """Test history-deals command dispatches correctly."""
-        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
-        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
-        args = _make_args(
-            command="history-deals",
-            date_from=dt_from,
-            date_to=dt_to,
-            group=None,
-            symbol=None,
-            ticket=12345,
-            position=None,
-        )
-        _fetch_trading(mock_client, args)
-        mock_client.history_deals_get_as_df.assert_called_once_with(
-            date_from=dt_from,
-            date_to=dt_to,
-            group=None,
-            symbol=None,
-            ticket=12345,
-            position=None,
-        )
-
-
-class TestFetchData:
-    """Tests for fetch_data dispatch."""
-
-    @pytest.mark.parametrize(
-        "command",
-        ["rates-from", "rates-from-pos", "rates-range"],
-    )
-    def test_rates_dispatch(
-        self,
-        mock_client: MagicMock,
-        command: str,
-    ) -> None:
-        """Test that rates commands dispatch through fetch_data."""
-        args = _make_args(
-            command=command,
-            symbol="EURUSD",
-            timeframe=1,
-            date_from=datetime(2024, 1, 1, tzinfo=UTC),
-            date_to=datetime(2024, 2, 1, tzinfo=UTC),
-            count=100,
-            start_pos=0,
-        )
-        result = fetch_data(mock_client, args)
-        assert isinstance(result, pd.DataFrame)
-
-    @pytest.mark.parametrize("command", ["ticks-from", "ticks-range"])
-    def test_ticks_dispatch(
-        self,
-        mock_client: MagicMock,
-        command: str,
-    ) -> None:
-        """Test that ticks commands dispatch through fetch_data."""
-        args = _make_args(
-            command=command,
-            symbol="EURUSD",
-            date_from=datetime(2024, 1, 1, tzinfo=UTC),
-            date_to=datetime(2024, 2, 1, tzinfo=UTC),
-            count=100,
-            flags=1,
-        )
-        result = fetch_data(mock_client, args)
-        assert isinstance(result, pd.DataFrame)
-
-    @pytest.mark.parametrize(
-        "command",
-        ["account-info", "terminal-info", "symbols", "symbol-info"],
-    )
-    def test_info_dispatch(
-        self,
-        mock_client: MagicMock,
-        command: str,
-    ) -> None:
-        """Test that info commands dispatch through fetch_data."""
-        args = _make_args(
-            command=command,
-            symbol="EURUSD",
-            group=None,
-        )
-        result = fetch_data(mock_client, args)
-        assert isinstance(result, pd.DataFrame)
-
-    @pytest.mark.parametrize(
-        "command",
-        ["orders", "positions", "history-orders", "history-deals"],
-    )
-    def test_trading_dispatch(
-        self,
-        mock_client: MagicMock,
-        command: str,
-    ) -> None:
-        """Test that trading commands dispatch through fetch_data."""
-        args = _make_args(
-            command=command,
-            symbol=None,
-            group=None,
-            ticket=None,
-            position=None,
-            date_from=datetime(2024, 1, 1, tzinfo=UTC),
-            date_to=datetime(2024, 2, 1, tzinfo=UTC),
-        )
-        result = fetch_data(mock_client, args)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_unknown_command_raises(self, mock_client: MagicMock) -> None:
-        """Test that unknown command raises ValueError."""
-        args = _make_args(command="unknown")
-        with pytest.raises(ValueError, match="Unknown command"):
-            fetch_data(mock_client, args)
-
-
-class TestBuildParser:
-    """Tests for _build_parser."""
-
-    def test_parser_creation(self) -> None:
-        """Test that parser is created successfully."""
-        parser = _build_parser()
-        assert parser.prog == "pdmt5"
-
-    @pytest.mark.parametrize(
-        ("argv", "expected_command"),
-        [
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "rates-from",
-                    "--symbol",
-                    "EURUSD",
-                    "--timeframe",
-                    "M1",
-                    "--date-from",
-                    "2024-01-01",
-                    "--count",
-                    "100",
-                ],
-                "rates-from",
-            ),
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "rates-from-pos",
-                    "--symbol",
-                    "EURUSD",
-                    "--timeframe",
-                    "H1",
-                    "--start-pos",
-                    "0",
-                    "--count",
-                    "50",
-                ],
-                "rates-from-pos",
-            ),
-            (
-                [
-                    "-o",
-                    "out.json",
-                    "rates-range",
-                    "--symbol",
-                    "EURUSD",
-                    "--timeframe",
-                    "D1",
-                    "--date-from",
-                    "2024-01-01",
-                    "--date-to",
-                    "2024-02-01",
-                ],
-                "rates-range",
-            ),
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "ticks-from",
-                    "--symbol",
-                    "EURUSD",
-                    "--date-from",
-                    "2024-01-01",
-                    "--count",
-                    "100",
-                    "--flags",
-                    "ALL",
-                ],
-                "ticks-from",
-            ),
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "ticks-range",
-                    "--symbol",
-                    "EURUSD",
-                    "--date-from",
-                    "2024-01-01",
-                    "--date-to",
-                    "2024-02-01",
-                    "--flags",
-                    "INFO",
-                ],
-                "ticks-range",
-            ),
-            (["-o", "out.csv", "account-info"], "account-info"),
-            (["-o", "out.csv", "terminal-info"], "terminal-info"),
-            (["-o", "out.csv", "symbols"], "symbols"),
-            (
-                ["-o", "out.csv", "symbol-info", "--symbol", "EURUSD"],
-                "symbol-info",
-            ),
-            (["-o", "out.csv", "orders"], "orders"),
-            (["-o", "out.csv", "positions"], "positions"),
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "history-orders",
-                    "--date-from",
-                    "2024-01-01",
-                    "--date-to",
-                    "2024-02-01",
-                ],
-                "history-orders",
-            ),
-            (
-                [
-                    "-o",
-                    "out.csv",
-                    "history-deals",
-                    "--ticket",
-                    "12345",
-                ],
-                "history-deals",
-            ),
-        ],
-    )
-    def test_parse_subcommands(
-        self,
-        argv: list[str],
-        expected_command: str,
-    ) -> None:
-        """Test parsing various subcommands."""
-        parser = _build_parser()
-        args = parser.parse_args(argv)
-        assert args.command == expected_command
-
-    def test_parse_connection_args(self) -> None:
-        """Test parsing connection arguments."""
-        parser = _build_parser()
-        args = parser.parse_args([
-            "--login",
-            "12345",
-            "--password",
-            "secret",
-            "--server",
-            "Demo",
-            "--path",
-            "/mt5/terminal.exe",
-            "--timeout",
-            "5000",
-            "-o",
-            "out.csv",
-            "account-info",
-        ])
-        assert args.login == 12345
-        assert args.password == "secret"  # noqa: S105
-        assert args.server == "Demo"
-        assert args.path == "/mt5/terminal.exe"
-        assert args.timeout == 5000
-
-    def test_parse_output_args(self) -> None:
-        """Test parsing output arguments."""
-        parser = _build_parser()
-        args = parser.parse_args([
-            "-o",
-            "out.db",
-            "--format",
-            "sqlite3",
-            "--table",
-            "rates",
-            "account-info",
-        ])
-        assert args.output == Path("out.db")
-        assert args.format == "sqlite3"
-        assert args.table == "rates"
-
-    def test_parse_log_level(self) -> None:
-        """Test parsing log level argument."""
-        parser = _build_parser()
-        args = parser.parse_args([
-            "--log-level",
-            "DEBUG",
-            "-o",
-            "out.csv",
-            "account-info",
-        ])
-        assert args.log_level == "DEBUG"
-
-
-class TestMain:
-    """Tests for main entry point."""
-
-    def test_main_success(
+    def test_orders(
         self,
         tmp_path: Path,
-        mocker: MockerFixture,
+        mock_client: MagicMock,
     ) -> None:
-        """Test successful main execution."""
-        sample_df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-        mock_client = MagicMock()
-        mock_client.account_info_as_df.return_value = sample_df
-        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        """Test orders command."""
         output = tmp_path / "out.csv"
-        main(["-o", str(output), "account-info"])
-        mock_client.initialize_and_login_mt5.assert_called_once()
-        mock_client.shutdown.assert_called_once()
-        assert output.exists()
-        result = pd.read_csv(output)
-        pd.testing.assert_frame_equal(result, sample_df)
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "orders",
+                "--symbol",
+                "EURUSD",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.orders_get_as_df.assert_called_once()
 
-    def test_main_with_connection_args(
+    def test_positions(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test positions command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "positions"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.positions_get_as_df.assert_called_once()
+
+    def test_history_orders(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test history-orders command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "history-orders",
+                "--date-from",
+                "2024-01-01",
+                "--date-to",
+                "2024-02-01",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.history_orders_get_as_df.assert_called_once()
+
+    def test_history_deals(
+        self,
+        tmp_path: Path,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test history-deals command."""
+        output = tmp_path / "out.csv"
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "history-deals",
+                "--ticket",
+                "12345",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.history_deals_get_as_df.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Callback / shared options
+# ---------------------------------------------------------------------------
+
+
+class TestCallback:
+    """Tests for callback (shared options)."""
+
+    def test_format_detection_error(self, tmp_path: Path) -> None:
+        """Test that bad extension triggers a user-friendly error."""
+        output = tmp_path / "out.xyz"
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "account-info"],
+        )
+        assert result.exit_code != 0
+        assert "Cannot detect format" in result.output
+
+    def test_connection_args_forwarded(
         self,
         tmp_path: Path,
         mocker: MockerFixture,
     ) -> None:
-        """Test main with connection arguments."""
+        """Test that connection arguments reach Mt5Config."""
         mock_client = MagicMock()
         mock_client.account_info_as_df.return_value = pd.DataFrame({"a": [1]})
-        mock_constructor = mocker.patch(
+        mocker.patch(
             "pdmt5.cli.Mt5DataClient",
             return_value=mock_client,
         )
-        mocker.patch("pdmt5.cli.Mt5Config")
-        output = tmp_path / "out.json"
-        main([
-            "--login",
-            "123",
-            "--password",
-            "pw",
-            "--server",
-            "srv",
-            "-o",
-            str(output),
-            "account-info",
-        ])
-        mock_constructor.assert_called_once()
-
-    def test_main_shutdown_on_error(
-        self,
-        tmp_path: Path,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test that shutdown is called even when fetch_data raises."""
-        mock_client = MagicMock()
-        mock_client.account_info_as_df.side_effect = RuntimeError("MT5 error")
-        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        mock_config = mocker.patch("pdmt5.cli.Mt5Config")
         output = tmp_path / "out.csv"
-        with pytest.raises(RuntimeError, match="MT5 error"):
-            main(["-o", str(output), "account-info"])
-        mock_client.shutdown.assert_called_once()
+        result = runner.invoke(
+            app,
+            [
+                "--login",
+                "123",
+                "--password",
+                "pw",
+                "--server",
+                "srv",
+                "-o",
+                str(output),
+                "account-info",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_config.assert_called_once_with(
+            path=None,
+            login=123,
+            password="pw",
+            server="srv",
+            timeout=None,
+        )
 
-    def test_main_format_detection_error(
+    def test_explicit_format(
         self,
         tmp_path: Path,
-        mocker: MockerFixture,
+        mock_client: MagicMock,  # noqa: ARG002
     ) -> None:
-        """Test main exits on format detection error."""
-        mocker.patch("pdmt5.cli.Mt5DataClient")
-        output = tmp_path / "out.xyz"
-        with pytest.raises(SystemExit):
-            main(["-o", str(output), "account-info"])
-
-    def test_main_explicit_format(
-        self,
-        tmp_path: Path,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test main with explicit format flag."""
-        mock_client = MagicMock()
-        mock_client.account_info_as_df.return_value = pd.DataFrame({"a": [1]})
-        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        """Test explicit --format flag."""
         output = tmp_path / "out.txt"
-        main(["-o", str(output), "--format", "json", "account-info"])
+        result = runner.invoke(
+            app,
+            ["-o", str(output), "--format", "json", "account-info"],
+        )
+        assert result.exit_code == 0, result.output
         assert output.exists()
 
-    def test_main_sqlite3_with_table(
+    def test_sqlite3_with_table(
         self,
         tmp_path: Path,
         mocker: MockerFixture,
     ) -> None:
-        """Test main with SQLite3 format and custom table name."""
+        """Test SQLite3 output with custom table name."""
         mock_client = MagicMock()
-        mock_client.symbols_get_as_df.return_value = pd.DataFrame({"s": ["EURUSD"]})
-        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        mock_client.symbols_get_as_df.return_value = pd.DataFrame(
+            {"s": ["EURUSD"]},
+        )
+        mocker.patch(
+            "pdmt5.cli.Mt5DataClient",
+            return_value=mock_client,
+        )
         output = tmp_path / "out.db"
-        main([
-            "-o",
-            str(output),
-            "--table",
-            "symbols",
-            "symbols",
-            "--group",
-            "*USD*",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "-o",
+                str(output),
+                "--table",
+                "symbols",
+                "symbols",
+                "--group",
+                "*USD*",
+            ],
+        )
+        assert result.exit_code == 0, result.output
         with sqlite3.connect(output) as conn:
-            result = pd.read_sql(  # type: ignore[reportUnknownMemberType]
+            result_df = pd.read_sql(  # type: ignore[reportUnknownMemberType]
                 "SELECT * FROM symbols",
                 conn,
             )
-        assert len(result) == 1
+        assert len(result_df) == 1
+
+
+# ---------------------------------------------------------------------------
+# main entry point
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Tests for the main entry point."""
+
+    def test_main_invokes_app(self, mocker: MockerFixture) -> None:
+        """Test that main() calls the typer app."""
+        mock_app = mocker.patch("pdmt5.cli.app")
+        main()
+        mock_app.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,819 @@
+"""Tests for pdmt5.cli module."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from pytest_mock import MockerFixture  # noqa: TC002
+
+from pdmt5.cli import (
+    TICK_FLAG_MAP,
+    TIMEFRAME_MAP,
+    _build_parser,  # type: ignore[reportPrivateUsage]
+    _fetch_info,  # type: ignore[reportPrivateUsage]
+    _fetch_rates,  # type: ignore[reportPrivateUsage]
+    _fetch_ticks,  # type: ignore[reportPrivateUsage]
+    _fetch_trading,  # type: ignore[reportPrivateUsage]
+    detect_format,
+    export_dataframe,
+    fetch_data,
+    main,
+    parse_datetime,
+    parse_tick_flags,
+    parse_timeframe,
+)
+
+
+class TestDetectFormat:
+    """Tests for detect_format."""
+
+    def test_explicit_format_returned(self, tmp_path: Path) -> None:
+        """Test that explicit format overrides extension."""
+        result = detect_format(tmp_path / "data.txt", explicit_format="csv")
+        assert result == "csv"
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("data.csv", "csv"),
+            ("data.json", "json"),
+            ("data.parquet", "parquet"),
+            ("data.pq", "parquet"),
+            ("data.db", "sqlite3"),
+            ("data.sqlite", "sqlite3"),
+            ("data.sqlite3", "sqlite3"),
+            ("DATA.CSV", "csv"),
+            ("DATA.JSON", "json"),
+            ("DATA.PARQUET", "parquet"),
+        ],
+    )
+    def test_auto_detect_from_extension(
+        self,
+        tmp_path: Path,
+        filename: str,
+        expected: str,
+    ) -> None:
+        """Test format auto-detection from file extension."""
+        result = detect_format(tmp_path / filename)
+        assert result == expected
+
+    def test_unknown_extension_raises(self, tmp_path: Path) -> None:
+        """Test that unknown extension raises ValueError."""
+        with pytest.raises(ValueError, match="Cannot detect format"):
+            detect_format(tmp_path / "data.xyz")
+
+
+class TestExportDataframe:
+    """Tests for export_dataframe."""
+
+    @pytest.fixture
+    def sample_df(self) -> pd.DataFrame:
+        """Create a sample DataFrame for testing."""
+        return pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+    def test_export_csv(self, tmp_path: Path, sample_df: pd.DataFrame) -> None:
+        """Test CSV export."""
+        output = tmp_path / "out.csv"
+        export_dataframe(sample_df, output, "csv")
+        result = pd.read_csv(output)
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_export_json(self, tmp_path: Path, sample_df: pd.DataFrame) -> None:
+        """Test JSON export."""
+        output = tmp_path / "out.json"
+        export_dataframe(sample_df, output, "json")
+        with output.open() as f:
+            records = json.load(f)
+        assert len(records) == 3
+        assert records[0]["a"] == 1
+
+    def test_export_parquet(self, tmp_path: Path, sample_df: pd.DataFrame) -> None:
+        """Test Parquet export."""
+        output = tmp_path / "out.parquet"
+        export_dataframe(sample_df, output, "parquet")
+        result = pd.read_parquet(output)
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_export_sqlite3(self, tmp_path: Path, sample_df: pd.DataFrame) -> None:
+        """Test SQLite3 export."""
+        output = tmp_path / "out.db"
+        export_dataframe(sample_df, output, "sqlite3", table_name="test_table")
+        with sqlite3.connect(output) as conn:
+            result = pd.read_sql(  # type: ignore[reportUnknownMemberType]
+                "SELECT * FROM test_table",
+                conn,
+            )
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_unsupported_format_raises(
+        self,
+        tmp_path: Path,
+        sample_df: pd.DataFrame,
+    ) -> None:
+        """Test that unsupported format raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported output format"):
+            export_dataframe(sample_df, tmp_path / "out.txt", "xml")
+
+
+class TestParseDatetime:
+    """Tests for parse_datetime."""
+
+    def test_valid_date(self) -> None:
+        """Test parsing a date string."""
+        result = parse_datetime("2024-01-15")
+        assert result == datetime(2024, 1, 15, tzinfo=UTC)
+
+    def test_valid_datetime_with_tz(self) -> None:
+        """Test parsing a datetime with timezone."""
+        result = parse_datetime("2024-01-15T12:00:00+00:00")
+        assert result == datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+    def test_invalid_format_raises(self) -> None:
+        """Test that invalid format raises ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid datetime"):
+            parse_datetime("not-a-date")
+
+
+class TestParseTimeframe:
+    """Tests for parse_timeframe."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("M1", 1), ("h1", 16385), ("D1", 16408), ("MN1", 49153)],
+    )
+    def test_named_timeframe(self, value: str, expected: int) -> None:
+        """Test parsing named timeframes."""
+        assert parse_timeframe(value) == expected
+
+    def test_integer_timeframe(self) -> None:
+        """Test parsing integer timeframe."""
+        assert parse_timeframe("42") == 42
+
+    def test_invalid_timeframe_raises(self) -> None:
+        """Test that invalid timeframe raises ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid timeframe"):
+            parse_timeframe("INVALID")
+
+
+class TestParseTickFlags:
+    """Tests for parse_tick_flags."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("ALL", 1), ("info", 2), ("TRADE", 4)],
+    )
+    def test_named_flag(self, value: str, expected: int) -> None:
+        """Test parsing named tick flags."""
+        assert parse_tick_flags(value) == expected
+
+    def test_integer_flag(self) -> None:
+        """Test parsing integer tick flag."""
+        assert parse_tick_flags("7") == 7
+
+    def test_invalid_flag_raises(self) -> None:
+        """Test that invalid flag raises ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid tick flags"):
+            parse_tick_flags("INVALID")
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_timeframe_map_has_expected_keys(self) -> None:
+        """Test that TIMEFRAME_MAP contains standard timeframes."""
+        for key in ("M1", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"):
+            assert key in TIMEFRAME_MAP
+
+    def test_tick_flag_map_has_expected_keys(self) -> None:
+        """Test that TICK_FLAG_MAP contains standard flags."""
+        assert set(TICK_FLAG_MAP) == {"ALL", "INFO", "TRADE"}
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    """Create an argparse.Namespace with given attributes."""
+    return argparse.Namespace(**kwargs)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock Mt5DataClient."""
+    client = MagicMock()
+    sample_df = pd.DataFrame({"col": [1]})
+    client.copy_rates_from_as_df.return_value = sample_df
+    client.copy_rates_from_pos_as_df.return_value = sample_df
+    client.copy_rates_range_as_df.return_value = sample_df
+    client.copy_ticks_from_as_df.return_value = sample_df
+    client.copy_ticks_range_as_df.return_value = sample_df
+    client.account_info_as_df.return_value = sample_df
+    client.terminal_info_as_df.return_value = sample_df
+    client.symbols_get_as_df.return_value = sample_df
+    client.symbol_info_as_df.return_value = sample_df
+    client.orders_get_as_df.return_value = sample_df
+    client.positions_get_as_df.return_value = sample_df
+    client.history_orders_get_as_df.return_value = sample_df
+    client.history_deals_get_as_df.return_value = sample_df
+    return client
+
+
+class TestFetchRates:
+    """Tests for _fetch_rates."""
+
+    def test_rates_from(self, mock_client: MagicMock) -> None:
+        """Test rates-from command dispatches correctly."""
+        dt = datetime(2024, 1, 1, tzinfo=UTC)
+        args = _make_args(
+            command="rates-from",
+            symbol="EURUSD",
+            timeframe=1,
+            date_from=dt,
+            count=100,
+        )
+        _fetch_rates(mock_client, args)
+        mock_client.copy_rates_from_as_df.assert_called_once_with(
+            symbol="EURUSD",
+            timeframe=1,
+            date_from=dt,
+            count=100,
+        )
+
+    def test_rates_from_pos(self, mock_client: MagicMock) -> None:
+        """Test rates-from-pos command dispatches correctly."""
+        args = _make_args(
+            command="rates-from-pos",
+            symbol="GBPUSD",
+            timeframe=16385,
+            start_pos=0,
+            count=50,
+        )
+        _fetch_rates(mock_client, args)
+        mock_client.copy_rates_from_pos_as_df.assert_called_once_with(
+            symbol="GBPUSD",
+            timeframe=16385,
+            start_pos=0,
+            count=50,
+        )
+
+    def test_rates_range(self, mock_client: MagicMock) -> None:
+        """Test rates-range command dispatches correctly."""
+        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
+        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
+        args = _make_args(
+            command="rates-range",
+            symbol="USDJPY",
+            timeframe=16408,
+            date_from=dt_from,
+            date_to=dt_to,
+        )
+        _fetch_rates(mock_client, args)
+        mock_client.copy_rates_range_as_df.assert_called_once_with(
+            symbol="USDJPY",
+            timeframe=16408,
+            date_from=dt_from,
+            date_to=dt_to,
+        )
+
+
+class TestFetchTicks:
+    """Tests for _fetch_ticks."""
+
+    def test_ticks_from(self, mock_client: MagicMock) -> None:
+        """Test ticks-from command dispatches correctly."""
+        dt = datetime(2024, 1, 1, tzinfo=UTC)
+        args = _make_args(
+            command="ticks-from",
+            symbol="EURUSD",
+            date_from=dt,
+            count=100,
+            flags=1,
+        )
+        _fetch_ticks(mock_client, args)
+        mock_client.copy_ticks_from_as_df.assert_called_once_with(
+            symbol="EURUSD",
+            date_from=dt,
+            count=100,
+            flags=1,
+        )
+
+    def test_ticks_range(self, mock_client: MagicMock) -> None:
+        """Test ticks-range command dispatches correctly."""
+        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
+        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
+        args = _make_args(
+            command="ticks-range",
+            symbol="EURUSD",
+            date_from=dt_from,
+            date_to=dt_to,
+            flags=2,
+        )
+        _fetch_ticks(mock_client, args)
+        mock_client.copy_ticks_range_as_df.assert_called_once_with(
+            symbol="EURUSD",
+            date_from=dt_from,
+            date_to=dt_to,
+            flags=2,
+        )
+
+
+class TestFetchInfo:
+    """Tests for _fetch_info."""
+
+    def test_account_info(self, mock_client: MagicMock) -> None:
+        """Test account-info command dispatches correctly."""
+        args = _make_args(command="account-info")
+        _fetch_info(mock_client, args)
+        mock_client.account_info_as_df.assert_called_once()
+
+    def test_terminal_info(self, mock_client: MagicMock) -> None:
+        """Test terminal-info command dispatches correctly."""
+        args = _make_args(command="terminal-info")
+        _fetch_info(mock_client, args)
+        mock_client.terminal_info_as_df.assert_called_once()
+
+    def test_symbols(self, mock_client: MagicMock) -> None:
+        """Test symbols command dispatches correctly."""
+        args = _make_args(command="symbols", group="*USD*")
+        _fetch_info(mock_client, args)
+        mock_client.symbols_get_as_df.assert_called_once_with(group="*USD*")
+
+    def test_symbol_info(self, mock_client: MagicMock) -> None:
+        """Test symbol-info command dispatches correctly."""
+        args = _make_args(command="symbol-info", symbol="EURUSD")
+        _fetch_info(mock_client, args)
+        mock_client.symbol_info_as_df.assert_called_once_with(symbol="EURUSD")
+
+
+class TestFetchTrading:
+    """Tests for _fetch_trading."""
+
+    def test_orders(self, mock_client: MagicMock) -> None:
+        """Test orders command dispatches correctly."""
+        args = _make_args(
+            command="orders",
+            symbol="EURUSD",
+            group=None,
+            ticket=None,
+        )
+        _fetch_trading(mock_client, args)
+        mock_client.orders_get_as_df.assert_called_once_with(
+            symbol="EURUSD",
+            group=None,
+            ticket=None,
+        )
+
+    def test_positions(self, mock_client: MagicMock) -> None:
+        """Test positions command dispatches correctly."""
+        args = _make_args(
+            command="positions",
+            symbol=None,
+            group="*USD*",
+            ticket=None,
+        )
+        _fetch_trading(mock_client, args)
+        mock_client.positions_get_as_df.assert_called_once_with(
+            symbol=None,
+            group="*USD*",
+            ticket=None,
+        )
+
+    def test_history_orders(self, mock_client: MagicMock) -> None:
+        """Test history-orders command dispatches correctly."""
+        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
+        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
+        args = _make_args(
+            command="history-orders",
+            date_from=dt_from,
+            date_to=dt_to,
+            group=None,
+            symbol="EURUSD",
+            ticket=None,
+            position=None,
+        )
+        _fetch_trading(mock_client, args)
+        mock_client.history_orders_get_as_df.assert_called_once_with(
+            date_from=dt_from,
+            date_to=dt_to,
+            group=None,
+            symbol="EURUSD",
+            ticket=None,
+            position=None,
+        )
+
+    def test_history_deals(self, mock_client: MagicMock) -> None:
+        """Test history-deals command dispatches correctly."""
+        dt_from = datetime(2024, 1, 1, tzinfo=UTC)
+        dt_to = datetime(2024, 2, 1, tzinfo=UTC)
+        args = _make_args(
+            command="history-deals",
+            date_from=dt_from,
+            date_to=dt_to,
+            group=None,
+            symbol=None,
+            ticket=12345,
+            position=None,
+        )
+        _fetch_trading(mock_client, args)
+        mock_client.history_deals_get_as_df.assert_called_once_with(
+            date_from=dt_from,
+            date_to=dt_to,
+            group=None,
+            symbol=None,
+            ticket=12345,
+            position=None,
+        )
+
+
+class TestFetchData:
+    """Tests for fetch_data dispatch."""
+
+    @pytest.mark.parametrize(
+        "command",
+        ["rates-from", "rates-from-pos", "rates-range"],
+    )
+    def test_rates_dispatch(
+        self,
+        mock_client: MagicMock,
+        command: str,
+    ) -> None:
+        """Test that rates commands dispatch through fetch_data."""
+        args = _make_args(
+            command=command,
+            symbol="EURUSD",
+            timeframe=1,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
+            date_to=datetime(2024, 2, 1, tzinfo=UTC),
+            count=100,
+            start_pos=0,
+        )
+        result = fetch_data(mock_client, args)
+        assert isinstance(result, pd.DataFrame)
+
+    @pytest.mark.parametrize("command", ["ticks-from", "ticks-range"])
+    def test_ticks_dispatch(
+        self,
+        mock_client: MagicMock,
+        command: str,
+    ) -> None:
+        """Test that ticks commands dispatch through fetch_data."""
+        args = _make_args(
+            command=command,
+            symbol="EURUSD",
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
+            date_to=datetime(2024, 2, 1, tzinfo=UTC),
+            count=100,
+            flags=1,
+        )
+        result = fetch_data(mock_client, args)
+        assert isinstance(result, pd.DataFrame)
+
+    @pytest.mark.parametrize(
+        "command",
+        ["account-info", "terminal-info", "symbols", "symbol-info"],
+    )
+    def test_info_dispatch(
+        self,
+        mock_client: MagicMock,
+        command: str,
+    ) -> None:
+        """Test that info commands dispatch through fetch_data."""
+        args = _make_args(
+            command=command,
+            symbol="EURUSD",
+            group=None,
+        )
+        result = fetch_data(mock_client, args)
+        assert isinstance(result, pd.DataFrame)
+
+    @pytest.mark.parametrize(
+        "command",
+        ["orders", "positions", "history-orders", "history-deals"],
+    )
+    def test_trading_dispatch(
+        self,
+        mock_client: MagicMock,
+        command: str,
+    ) -> None:
+        """Test that trading commands dispatch through fetch_data."""
+        args = _make_args(
+            command=command,
+            symbol=None,
+            group=None,
+            ticket=None,
+            position=None,
+            date_from=datetime(2024, 1, 1, tzinfo=UTC),
+            date_to=datetime(2024, 2, 1, tzinfo=UTC),
+        )
+        result = fetch_data(mock_client, args)
+        assert isinstance(result, pd.DataFrame)
+
+    def test_unknown_command_raises(self, mock_client: MagicMock) -> None:
+        """Test that unknown command raises ValueError."""
+        args = _make_args(command="unknown")
+        with pytest.raises(ValueError, match="Unknown command"):
+            fetch_data(mock_client, args)
+
+
+class TestBuildParser:
+    """Tests for _build_parser."""
+
+    def test_parser_creation(self) -> None:
+        """Test that parser is created successfully."""
+        parser = _build_parser()
+        assert parser.prog == "pdmt5"
+
+    @pytest.mark.parametrize(
+        ("argv", "expected_command"),
+        [
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "rates-from",
+                    "--symbol",
+                    "EURUSD",
+                    "--timeframe",
+                    "M1",
+                    "--date-from",
+                    "2024-01-01",
+                    "--count",
+                    "100",
+                ],
+                "rates-from",
+            ),
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "rates-from-pos",
+                    "--symbol",
+                    "EURUSD",
+                    "--timeframe",
+                    "H1",
+                    "--start-pos",
+                    "0",
+                    "--count",
+                    "50",
+                ],
+                "rates-from-pos",
+            ),
+            (
+                [
+                    "-o",
+                    "out.json",
+                    "rates-range",
+                    "--symbol",
+                    "EURUSD",
+                    "--timeframe",
+                    "D1",
+                    "--date-from",
+                    "2024-01-01",
+                    "--date-to",
+                    "2024-02-01",
+                ],
+                "rates-range",
+            ),
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "ticks-from",
+                    "--symbol",
+                    "EURUSD",
+                    "--date-from",
+                    "2024-01-01",
+                    "--count",
+                    "100",
+                    "--flags",
+                    "ALL",
+                ],
+                "ticks-from",
+            ),
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "ticks-range",
+                    "--symbol",
+                    "EURUSD",
+                    "--date-from",
+                    "2024-01-01",
+                    "--date-to",
+                    "2024-02-01",
+                    "--flags",
+                    "INFO",
+                ],
+                "ticks-range",
+            ),
+            (["-o", "out.csv", "account-info"], "account-info"),
+            (["-o", "out.csv", "terminal-info"], "terminal-info"),
+            (["-o", "out.csv", "symbols"], "symbols"),
+            (
+                ["-o", "out.csv", "symbol-info", "--symbol", "EURUSD"],
+                "symbol-info",
+            ),
+            (["-o", "out.csv", "orders"], "orders"),
+            (["-o", "out.csv", "positions"], "positions"),
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "history-orders",
+                    "--date-from",
+                    "2024-01-01",
+                    "--date-to",
+                    "2024-02-01",
+                ],
+                "history-orders",
+            ),
+            (
+                [
+                    "-o",
+                    "out.csv",
+                    "history-deals",
+                    "--ticket",
+                    "12345",
+                ],
+                "history-deals",
+            ),
+        ],
+    )
+    def test_parse_subcommands(
+        self,
+        argv: list[str],
+        expected_command: str,
+    ) -> None:
+        """Test parsing various subcommands."""
+        parser = _build_parser()
+        args = parser.parse_args(argv)
+        assert args.command == expected_command
+
+    def test_parse_connection_args(self) -> None:
+        """Test parsing connection arguments."""
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--login",
+            "12345",
+            "--password",
+            "secret",
+            "--server",
+            "Demo",
+            "--path",
+            "/mt5/terminal.exe",
+            "--timeout",
+            "5000",
+            "-o",
+            "out.csv",
+            "account-info",
+        ])
+        assert args.login == 12345
+        assert args.password == "secret"  # noqa: S105
+        assert args.server == "Demo"
+        assert args.path == "/mt5/terminal.exe"
+        assert args.timeout == 5000
+
+    def test_parse_output_args(self) -> None:
+        """Test parsing output arguments."""
+        parser = _build_parser()
+        args = parser.parse_args([
+            "-o",
+            "out.db",
+            "--format",
+            "sqlite3",
+            "--table",
+            "rates",
+            "account-info",
+        ])
+        assert args.output == Path("out.db")
+        assert args.format == "sqlite3"
+        assert args.table == "rates"
+
+    def test_parse_log_level(self) -> None:
+        """Test parsing log level argument."""
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--log-level",
+            "DEBUG",
+            "-o",
+            "out.csv",
+            "account-info",
+        ])
+        assert args.log_level == "DEBUG"
+
+
+class TestMain:
+    """Tests for main entry point."""
+
+    def test_main_success(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test successful main execution."""
+        sample_df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        mock_client = MagicMock()
+        mock_client.account_info_as_df.return_value = sample_df
+        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        output = tmp_path / "out.csv"
+        main(["-o", str(output), "account-info"])
+        mock_client.initialize_and_login_mt5.assert_called_once()
+        mock_client.shutdown.assert_called_once()
+        assert output.exists()
+        result = pd.read_csv(output)
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_main_with_connection_args(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test main with connection arguments."""
+        mock_client = MagicMock()
+        mock_client.account_info_as_df.return_value = pd.DataFrame({"a": [1]})
+        mock_constructor = mocker.patch(
+            "pdmt5.cli.Mt5DataClient",
+            return_value=mock_client,
+        )
+        mocker.patch("pdmt5.cli.Mt5Config")
+        output = tmp_path / "out.json"
+        main([
+            "--login",
+            "123",
+            "--password",
+            "pw",
+            "--server",
+            "srv",
+            "-o",
+            str(output),
+            "account-info",
+        ])
+        mock_constructor.assert_called_once()
+
+    def test_main_shutdown_on_error(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that shutdown is called even when fetch_data raises."""
+        mock_client = MagicMock()
+        mock_client.account_info_as_df.side_effect = RuntimeError("MT5 error")
+        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        output = tmp_path / "out.csv"
+        with pytest.raises(RuntimeError, match="MT5 error"):
+            main(["-o", str(output), "account-info"])
+        mock_client.shutdown.assert_called_once()
+
+    def test_main_format_detection_error(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test main exits on format detection error."""
+        mocker.patch("pdmt5.cli.Mt5DataClient")
+        output = tmp_path / "out.xyz"
+        with pytest.raises(SystemExit):
+            main(["-o", str(output), "account-info"])
+
+    def test_main_explicit_format(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test main with explicit format flag."""
+        mock_client = MagicMock()
+        mock_client.account_info_as_df.return_value = pd.DataFrame({"a": [1]})
+        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        output = tmp_path / "out.txt"
+        main(["-o", str(output), "--format", "json", "account-info"])
+        assert output.exists()
+
+    def test_main_sqlite3_with_table(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test main with SQLite3 format and custom table name."""
+        mock_client = MagicMock()
+        mock_client.symbols_get_as_df.return_value = pd.DataFrame({"s": ["EURUSD"]})
+        mocker.patch("pdmt5.cli.Mt5DataClient", return_value=mock_client)
+        output = tmp_path / "out.db"
+        main([
+            "-o",
+            str(output),
+            "--table",
+            "symbols",
+            "symbols",
+            "--group",
+            "*USD*",
+        ])
+        with sqlite3.connect(output) as conn:
+            result = pd.read_sql(  # type: ignore[reportUnknownMemberType]
+                "SELECT * FROM symbols",
+                conn,
+            )
+        assert len(result) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,7 +24,6 @@ class TestInit:
             "Mt5TradingError",
             "detect_format",
             "export_dataframe",
-            "fetch_data",
         ],
     )
     def test_exports_available(self, export: str) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,9 @@ class TestInit:
             "Mt5RuntimeError",
             "Mt5TradingClient",
             "Mt5TradingError",
+            "detect_format",
+            "export_dataframe",
+            "fetch_data",
         ],
     )
     def test_exports_available(self, export: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ required-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -258,6 +267,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +328,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -609,6 +639,7 @@ dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },
     { name = "pandas" },
     { name = "pydantic" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -633,6 +664,7 @@ requires-dist = [
     { name = "metatrader5", marker = "sys_platform == 'win32'", specifier = ">=5.0.4424" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "typer", specifier = ">=0.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -921,6 +953,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -944,6 +989,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -989,6 +1043,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
     { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,7 @@ source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "typer" },
 ]
@@ -663,6 +664,7 @@ dev = [
 requires-dist = [
     { name = "metatrader5", marker = "sys_platform == 'win32'", specifier = ">=5.0.4424" },
     { name = "pandas", specifier = ">=2.2.2" },
+    { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
@@ -700,6 +702,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050, upload-time = "2026-02-16T10:09:11.877Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918, upload-time = "2026-02-16T10:09:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811, upload-time = "2026-02-16T10:09:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766, upload-time = "2026-02-16T10:09:34.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669, upload-time = "2026-02-16T10:09:44.153Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698, upload-time = "2026-02-16T10:09:50.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds a comprehensive command-line interface (CLI) to pdmt5, enabling users to export MetaTrader5 data directly from the terminal to multiple formats (CSV, JSON, Parquet, SQLite3).

## Key Changes

- **New CLI module** (`pdmt5/cli.py`): Implements a full-featured argument parser with 12 subcommands for different data export operations:
  - Rates commands: `rates-from`, `rates-from-pos`, `rates-range`
  - Ticks commands: `ticks-from`, `ticks-range`
  - Info commands: `account-info`, `terminal-info`, `symbols`, `symbol-info`
  - Trading commands: `orders`, `positions`, `history-orders`, `history-deals`

- **Format detection and export**: 
  - `detect_format()` function auto-detects output format from file extension or accepts explicit format specification
  - `export_dataframe()` function handles exporting to CSV, JSON, Parquet, and SQLite3 formats

- **Argument parsing utilities**:
  - `parse_datetime()` for ISO 8601 datetime strings with UTC timezone handling
  - `parse_timeframe()` for named timeframes (M1, H1, D1, etc.) or integer values
  - `parse_tick_flags()` for tick flag names (ALL, INFO, TRADE) or integer values

- **Entry points**:
  - `main()` function orchestrates the full workflow: argument parsing, client initialization, data fetching, and export
  - `__main__.py` module enables running pdmt5 as `python -m pdmt5`
  - Console script entry point `pdmt5` in `pyproject.toml`

- **Public API exports**: Added `detect_format`, `export_dataframe`, and `fetch_data` to package `__init__.py`

- **Comprehensive test coverage** (`tests/test_cli.py`): 819 lines of tests covering all CLI functions, argument parsing, format detection, data export, and integration scenarios

## Notable Implementation Details

- Connection arguments (login, password, server, path, timeout) are optional and passed to `Mt5Config`
- Output format is auto-detected from file extension but can be overridden with `--format` flag
- SQLite3 export supports custom table names via `--table` argument
- Logging level is configurable via `--log-level` argument
- Client shutdown is guaranteed via try-finally block even on errors
- Timeframe and tick flag mappings support both named values and raw integers for flexibility

https://claude.ai/code/session_017EBy4YasebKbbTYEoSoCWU