### PR TITLE
Add shared MT5 constant parsing APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ from pdmt5 import (
 
 parse_timeframe("TIMEFRAME_M1")  # 1
 parse_timeframe("M1")  # 1
-parse_copy_ticks("COPY_TICKS_ALL")  # 3
-parse_copy_ticks("ALL")  # 3
+parse_copy_ticks("COPY_TICKS_ALL")  # -1
+parse_copy_ticks("ALL")  # -1
 parse_order_type("ORDER_TYPE_BUY")  # 0
 parse_order_type("BUY")  # 0
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Pandas-based data handler for MetaTrader 5
 - 📊 **Pandas Integration**: DataFrame and dictionary helpers for easy analysis
 - 🔧 **Type Safety**: Full type hints with strict pyright checking and pydantic validation
 - 🏦 **Comprehensive MT5 Coverage**: Account info, market data, tick data, orders, positions, and more
+- 🧭 **Canonical MT5 Constants**: Shared parsing for timeframes, COPY_TICKS flags,
+  and ORDER_TYPE values with official names, short aliases, or valid integers
 - 🚀 **Context Manager Support**: Clean initialization and cleanup with `with` statements (initialize only)
 - 📈 **Time Series Ready**: OHLCV data with proper datetime indexing
 - 🛡️ **Robust Error Handling**: Custom exceptions with detailed MT5 error information
@@ -47,9 +49,8 @@ uv sync
 ## Quick Start
 
 ```python
-import MetaTrader5 as mt5
 from datetime import datetime
-from pdmt5 import Mt5DataClient, Mt5Config
+from pdmt5 import Mt5DataClient, Mt5Config, parse_timeframe
 
 # Configure connection
 config = Mt5Config(
@@ -71,7 +72,7 @@ with Mt5DataClient(config=config) as client:
     # Get OHLCV data as DataFrame
     rates = client.copy_rates_from_as_df(
         symbol="EURUSD",
-        timeframe=mt5.TIMEFRAME_H1,
+        timeframe=parse_timeframe("H1"),
         date_from=datetime(2024, 1, 1),
         count=100
     )
@@ -166,6 +167,58 @@ Extends Mt5Client with pandas DataFrame and dictionary conversions:
   - Input validation for dates, counts, and positions
   - Pydantic-based configuration via `Mt5Config`
 
+### MT5 Constant Parsing
+
+pdmt5 is the canonical source for parsing MT5 constants shared by CLI, HTTP API,
+and other application layers. The constants module does not import
+`MetaTrader5`, so it can be used for request validation and JSON schema
+generation without a live terminal.
+
+```python
+from pdmt5 import (
+    list_copy_ticks_names,
+    list_copy_ticks_values,
+    list_order_type_names,
+    list_order_type_values,
+    list_timeframe_names,
+    list_timeframe_values,
+    parse_copy_ticks,
+    parse_order_type,
+    parse_timeframe,
+)
+
+parse_timeframe("TIMEFRAME_M1")  # 1
+parse_timeframe("M1")  # 1
+parse_copy_ticks("COPY_TICKS_ALL")  # 3
+parse_copy_ticks("ALL")  # 3
+parse_order_type("ORDER_TYPE_BUY")  # 0
+parse_order_type("BUY")  # 0
+
+# Integer values are accepted only when they belong to the requested family.
+parse_timeframe(16385)  # TIMEFRAME_H1
+parse_order_type(16385)  # raises ValueError
+
+# Use these helpers to build Pydantic JSON schema enums.
+timeframe_schema = {
+    "anyOf": [
+        {"type": "string", "enum": list_timeframe_names()},
+        {"type": "integer", "enum": list_timeframe_values()},
+    ],
+}
+copy_ticks_schema = {
+    "anyOf": [
+        {"type": "string", "enum": list_copy_ticks_names()},
+        {"type": "integer", "enum": list_copy_ticks_values()},
+    ],
+}
+order_type_schema = {
+    "anyOf": [
+        {"type": "string", "enum": list_order_type_names()},
+        {"type": "integer", "enum": list_order_type_values()},
+    ],
+}
+```
+
 ### Mt5TradingClient
 
 Advanced trading operations client that extends Mt5DataClient:
@@ -208,14 +261,14 @@ config = Mt5Config(
 ### Getting Historical Data
 
 ```python
-import MetaTrader5 as mt5
 from datetime import datetime
+from pdmt5 import Mt5DataClient, parse_timeframe
 
 with Mt5DataClient(config=config) as client:
     # Get last 1000 H1 bars for EURUSD as DataFrame
     df = client.copy_rates_from_as_df(
         symbol="EURUSD",
-        timeframe=mt5.TIMEFRAME_H1,
+        timeframe=parse_timeframe("TIMEFRAME_H1"),
         date_from=datetime.now(),
         count=1000
     )
@@ -229,6 +282,7 @@ with Mt5DataClient(config=config) as client:
 
 ```python
 from datetime import datetime, timedelta
+from pdmt5 import parse_copy_ticks
 
 with Mt5DataClient(config=config) as client:
     # Get ticks for the last hour as DataFrame
@@ -236,7 +290,7 @@ with Mt5DataClient(config=config) as client:
         symbol="EURUSD",
         date_from=datetime.now() - timedelta(hours=1),
         count=10000,
-        flags=mt5.COPY_TICKS_ALL
+        flags=parse_copy_ticks("COPY_TICKS_ALL")
     )
 
     # Tick data includes: time, bid, ask, last, volume, flags
@@ -395,11 +449,13 @@ This project maintains high code quality standards:
 The package provides detailed error information:
 
 ```python
-from pdmt5 import Mt5RuntimeError
+from pdmt5 import Mt5RuntimeError, parse_timeframe
 
 try:
     with Mt5DataClient(config=config) as client:
-        data = client.copy_rates_from("INVALID", mt5.TIMEFRAME_H1, datetime.now(), 100)
+        data = client.copy_rates_from(
+            "INVALID", parse_timeframe("H1"), datetime.now(), 100
+        )
 except Mt5RuntimeError as e:
     print(f"MT5 Error: {e}")
     print(f"Error code: {e.error_code}")

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,0 +1,3 @@
+# Constants
+
+::: pdmt5.constants

--- a/docs/api/dataframe.md
+++ b/docs/api/dataframe.md
@@ -59,13 +59,13 @@ with client:
 
 ```python
 from datetime import datetime
-import MetaTrader5 as mt5
+from pdmt5 import parse_copy_ticks, parse_timeframe
 
 with client:
     # Get OHLCV data
     rates_df = client.copy_rates_from_as_df(
         symbol="EURUSD",
-        timeframe=mt5.TIMEFRAME_H1,
+        timeframe=parse_timeframe("H1"),
         date_from=datetime(2024, 1, 1),
         count=1000
     )
@@ -75,7 +75,7 @@ with client:
         symbol="EURUSD",
         date_from=datetime(2024, 1, 1),
         count=1000,
-        flags=mt5.COPY_TICKS_ALL
+        flags=parse_copy_ticks("ALL")
     )
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -14,6 +14,13 @@ Base client class for MetaTrader 5 operations with connection management, low-le
 
 Core data client functionality and configuration, providing pandas-friendly interface to MetaTrader 5.
 
+### [Constants](constants.md)
+
+Canonical MT5 constant maps and parsers for timeframes, COPY_TICKS flags, and
+ORDER_TYPE values. Use these helpers when CLI, HTTP, or validation layers need
+to accept official names such as `TIMEFRAME_M1`, short aliases such as `M1`, or
+integer values.
+
 ### [Mt5TradingClient](trading.md)
 
 Advanced trading operations including position management, order analysis, and trading performance metrics with dry run support.
@@ -25,7 +32,8 @@ The package follows a layered architecture:
 1. **Base Layer** (`mt5.py`): Provides the base `Mt5Client` class with low-level MT5 API access and `Mt5RuntimeError` exception
 2. **Data Layer** (`dataframe.py`): Extends `Mt5Client` with configuration (`Mt5Config`) and pandas-friendly `Mt5DataClient` class
 3. **Trading Layer** (`trading.py`): Extends `Mt5DataClient` with advanced trading operations and `Mt5TradingError` exception
-4. **Utilities** (`utils.py`): Helper functions for time conversion and DataFrame manipulation
+4. **Constants** (`constants.py`): Shared MT5 constant parsing and schema helper values
+5. **Utilities** (`utils.py`): Helper functions for time conversion and DataFrame manipulation
 
 ## Usage Guidelines
 
@@ -41,7 +49,16 @@ All modules follow these conventions:
 ## Quick Start
 
 ```python
-from pdmt5 import Mt5Client, Mt5Config, Mt5DataClient, Mt5TradingClient
+from pdmt5 import (
+    Mt5Client,
+    Mt5Config,
+    Mt5DataClient,
+    Mt5TradingClient,
+    list_timeframe_names,
+    list_timeframe_values,
+    parse_copy_ticks,
+    parse_timeframe,
+)
 import MetaTrader5 as mt5
 from datetime import datetime
 
@@ -57,12 +74,19 @@ with Mt5DataClient(mt5=mt5, config=config) as client:
     # Optional: login when credentials are provided
     client.login(config.login, config.password, config.server)
     symbols_df = client.symbols_get_as_df()
-    rates_df = client.copy_rates_from_as_df("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
+    rates_df = client.copy_rates_from_as_df(
+        "EURUSD", parse_timeframe("H1"), datetime.now(), 100
+    )
 
 # Advanced trading operations with Mt5TradingClient
 with Mt5TradingClient(mt5=mt5, config=config) as client:
     # Close all positions for a symbol
     results = client.close_open_positions("EURUSD", dry_run=True)
+
+# Schema-friendly MT5 constant metadata
+timeframe_names = list_timeframe_names()
+timeframe_values = list_timeframe_values()
+tick_flags = parse_copy_ticks("COPY_TICKS_ALL")
 ```
 
 ## Examples

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -29,7 +29,6 @@ Custom runtime exception for trading-specific errors.
 ### Basic Trading Operations
 
 ```python
-import MetaTrader5 as mt5
 from pdmt5 import Mt5TradingClient, Mt5Config
 
 # Create configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ pdmt5 is a Python library that provides a pandas-based interface for handling Me
 
 - **MetaTrader 5 Integration**: Direct connection to MetaTrader 5 platform (Windows only)
 - **Pandas-based**: Leverages pandas for efficient data manipulation
+- **Canonical MT5 Constants**: Shared parsers for timeframes, COPY_TICKS flags,
+  and ORDER_TYPE values using official names, short aliases, or valid integers
 - **Type Safety**: Built with pydantic for robust data validation
 - **Financial Focus**: Designed specifically for trading and financial data analysis
 
@@ -22,7 +24,14 @@ pip install pdmt5
 ### Quick Start
 
 ```python
-from pdmt5 import Mt5Client, Mt5Config, Mt5DataClient, Mt5TradingClient
+from pdmt5 import (
+    Mt5Client,
+    Mt5Config,
+    Mt5DataClient,
+    Mt5TradingClient,
+    parse_copy_ticks,
+    parse_timeframe,
+)
 import MetaTrader5 as mt5
 from datetime import datetime
 
@@ -50,7 +59,7 @@ with Mt5DataClient(config=config) as client:
     symbols_df = client.symbols_get_as_df()
     # Get OHLCV data as DataFrame
     rates_df = client.copy_rates_from_as_df(
-        "EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100
+        "EURUSD", parse_timeframe("H1"), datetime.now(), 100
     )
     # Get account info as DataFrame
     account_df = client.account_info_as_df()
@@ -61,6 +70,10 @@ with Mt5TradingClient(config=config) as client:
     positions_df = client.positions_get_as_df()
     # Close positions for specific symbol (dry run)
     results = client.close_open_positions("EURUSD", dry_run=True)
+
+# Parse MT5 constants without importing the MetaTrader5 module
+timeframe = parse_timeframe("TIMEFRAME_H1")  # 16385
+tick_flags = parse_copy_ticks("ALL")  # 3
 ```
 
 ## Requirements
@@ -74,6 +87,7 @@ with Mt5TradingClient(config=config) as client:
 Browse the API documentation to learn about available modules and functions:
 
 - [Mt5Client](api/mt5.md) - Base client for low-level MT5 API access with context manager support
+- [Constants](api/constants.md) - Canonical MT5 constant parsing and schema helper values
 - [Mt5DataClient & Mt5Config](api/dataframe.md) - Pandas-friendly data client with DataFrame conversions
 - [Mt5TradingClient](api/trading.md) - Advanced trading operations with position management
 - [Utility Functions](api/utils.md) - Helper decorators and functions for data processing

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ with Mt5TradingClient(config=config) as client:
 
 # Parse MT5 constants without importing the MetaTrader5 module
 timeframe = parse_timeframe("TIMEFRAME_H1")  # 16385
-tick_flags = parse_copy_ticks("ALL")  # 3
+tick_flags = parse_copy_ticks("ALL")  # -1
 ```
 
 ## Requirements

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - API Reference:
     - Overview: api/index.md
     - MetaTrader5: api/mt5.md
+    - Constants: api/constants.md
     - DataFrame: api/dataframe.md
     - Trading: api/trading.md
     - Utilities: api/utils.md

--- a/pdmt5/__init__.py
+++ b/pdmt5/__init__.py
@@ -30,14 +30,14 @@ __version__ = version(__package__) if __package__ else None
 
 __all__ = [
     "COPY_TICKS_MAP",
+    "ORDER_TYPE_MAP",
+    "TIMEFRAME_MAP",
     "Mt5Client",
     "Mt5Config",
     "Mt5DataClient",
     "Mt5RuntimeError",
     "Mt5TradingClient",
     "Mt5TradingError",
-    "ORDER_TYPE_MAP",
-    "TIMEFRAME_MAP",
     "get_copy_ticks_name",
     "get_copy_ticks_value",
     "get_order_type_name",

--- a/pdmt5/__init__.py
+++ b/pdmt5/__init__.py
@@ -2,6 +2,26 @@
 
 from importlib.metadata import version
 
+from .constants import (
+    COPY_TICKS_MAP,
+    ORDER_TYPE_MAP,
+    TIMEFRAME_MAP,
+    get_copy_ticks_name,
+    get_copy_ticks_value,
+    get_order_type_name,
+    get_order_type_value,
+    get_timeframe_name,
+    get_timeframe_value,
+    list_copy_ticks_names,
+    list_copy_ticks_values,
+    list_order_type_names,
+    list_order_type_values,
+    list_timeframe_names,
+    list_timeframe_values,
+    parse_copy_ticks,
+    parse_order_type,
+    parse_timeframe,
+)
 from .dataframe import Mt5Config, Mt5DataClient
 from .mt5 import Mt5Client, Mt5RuntimeError
 from .trading import Mt5TradingClient, Mt5TradingError
@@ -9,10 +29,28 @@ from .trading import Mt5TradingClient, Mt5TradingError
 __version__ = version(__package__) if __package__ else None
 
 __all__ = [
+    "COPY_TICKS_MAP",
     "Mt5Client",
     "Mt5Config",
     "Mt5DataClient",
     "Mt5RuntimeError",
     "Mt5TradingClient",
     "Mt5TradingError",
+    "ORDER_TYPE_MAP",
+    "TIMEFRAME_MAP",
+    "get_copy_ticks_name",
+    "get_copy_ticks_value",
+    "get_order_type_name",
+    "get_order_type_value",
+    "get_timeframe_name",
+    "get_timeframe_value",
+    "list_copy_ticks_names",
+    "list_copy_ticks_values",
+    "list_order_type_names",
+    "list_order_type_values",
+    "list_timeframe_names",
+    "list_timeframe_values",
+    "parse_copy_ticks",
+    "parse_order_type",
+    "parse_timeframe",
 ]

--- a/pdmt5/constants.py
+++ b/pdmt5/constants.py
@@ -55,30 +55,27 @@ _ORDER_TYPE_OFFICIAL_NAMES: Final[tuple[str, ...]] = tuple(
     f"ORDER_TYPE_{name}" for name in _ORDER_TYPE_ALIASES
 )
 
-_TIMEFRAME_OFFICIAL_MAP: Final[dict[str, int]] = {
-    name: value
-    for name, value in zip(
+_TIMEFRAME_OFFICIAL_MAP: Final[dict[str, int]] = dict(
+    zip(
         _TIMEFRAME_OFFICIAL_NAMES,
         _TIMEFRAME_ALIASES.values(),
         strict=True,
     )
-}
-_COPY_TICKS_OFFICIAL_MAP: Final[dict[str, int]] = {
-    name: value
-    for name, value in zip(
+)
+_COPY_TICKS_OFFICIAL_MAP: Final[dict[str, int]] = dict(
+    zip(
         _COPY_TICKS_OFFICIAL_NAMES,
         _COPY_TICKS_ALIASES.values(),
         strict=True,
     )
-}
-_ORDER_TYPE_OFFICIAL_MAP: Final[dict[str, int]] = {
-    name: value
-    for name, value in zip(
+)
+_ORDER_TYPE_OFFICIAL_MAP: Final[dict[str, int]] = dict(
+    zip(
         _ORDER_TYPE_OFFICIAL_NAMES,
         _ORDER_TYPE_ALIASES.values(),
         strict=True,
     )
-}
+)
 
 TIMEFRAME_MAP: Final[dict[str, int]] = {
     **_TIMEFRAME_OFFICIAL_MAP,
@@ -137,8 +134,6 @@ class _ConstantFamily:
         Returns:
             The matching constant name.
 
-        Raises:
-            ValueError: If the integer is not valid for this family.
         """
         parsed_value = _parse_constant(value, self)
         names = self.alias_names if prefer_alias else self.official_names
@@ -167,7 +162,18 @@ _ORDER_TYPE_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
 
 
 def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
-    """Parse a constant name or value for a family."""
+    """Parse a constant name or value for a family.
+
+    Args:
+        value: Constant name, alias, or integer value.
+        family: Constant family metadata.
+
+    Returns:
+        The validated integer constant.
+
+    Raises:
+        ValueError: If the name or integer value is not valid.
+    """
     if isinstance(value, str):
         normalized_value = value.strip().upper()
         if normalized_value in family.mapping:
@@ -181,9 +187,9 @@ def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
                 "or a valid integer value."
             )
             raise ValueError(message) from None
-    elif isinstance(value, bool) or not isinstance(value, int):
+    elif isinstance(value, bool):
         message = f"Invalid {family.label}: {value!r}. Use a name or integer value."
-        raise ValueError(message)
+        raise ValueError(message)  # noqa: TRY004
     else:
         parsed_value = value
 
@@ -207,8 +213,6 @@ def parse_timeframe(value: int | str) -> int:
     Returns:
         The validated MetaTrader 5 timeframe integer.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 timeframes.
     """
     return _parse_constant(value=value, family=_TIMEFRAME_FAMILY)
 
@@ -223,8 +227,6 @@ def parse_copy_ticks(value: int | str) -> int:
     Returns:
         The validated MetaTrader 5 COPY_TICKS integer.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 COPY_TICKS flags.
     """
     return _parse_constant(value=value, family=_COPY_TICKS_FAMILY)
 
@@ -239,8 +241,6 @@ def parse_order_type(value: int | str) -> int:
     Returns:
         The validated MetaTrader 5 ORDER_TYPE integer.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 order types.
     """
     return _parse_constant(value=value, family=_ORDER_TYPE_FAMILY)
 
@@ -275,8 +275,6 @@ def get_timeframe_value(name: str) -> int:
     Returns:
         The matching timeframe integer.
 
-    Raises:
-        ValueError: If the name is not valid for MT5 timeframes.
     """
     return parse_timeframe(name)
 
@@ -291,8 +289,6 @@ def get_timeframe_name(value: int, *, prefer_alias: bool = False) -> str:
     Returns:
         The matching timeframe name.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 timeframes.
     """
     return _TIMEFRAME_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
 
@@ -327,8 +323,6 @@ def get_copy_ticks_value(name: str) -> int:
     Returns:
         The matching COPY_TICKS integer.
 
-    Raises:
-        ValueError: If the name is not valid for MT5 COPY_TICKS flags.
     """
     return parse_copy_ticks(name)
 
@@ -343,8 +337,6 @@ def get_copy_ticks_name(value: int, *, prefer_alias: bool = False) -> str:
     Returns:
         The matching COPY_TICKS name.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 COPY_TICKS flags.
     """
     return _COPY_TICKS_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
 
@@ -379,8 +371,6 @@ def get_order_type_value(name: str) -> int:
     Returns:
         The matching ORDER_TYPE integer.
 
-    Raises:
-        ValueError: If the name is not valid for MT5 order types.
     """
     return parse_order_type(name)
 
@@ -395,8 +385,6 @@ def get_order_type_name(value: int, *, prefer_alias: bool = False) -> str:
     Returns:
         The matching ORDER_TYPE name.
 
-    Raises:
-        ValueError: If the value is not valid for MT5 order types.
     """
     return _ORDER_TYPE_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
 

--- a/pdmt5/constants.py
+++ b/pdmt5/constants.py
@@ -31,7 +31,7 @@ _TIMEFRAME_ALIASES: Final[dict[str, int]] = {
 _COPY_TICKS_ALIASES: Final[dict[str, int]] = {
     "INFO": 1,
     "TRADE": 2,
-    "ALL": 3,
+    "ALL": -1,
 }
 _ORDER_TYPE_ALIASES: Final[dict[str, int]] = {
     "BUY": 0,

--- a/pdmt5/constants.py
+++ b/pdmt5/constants.py
@@ -1,0 +1,423 @@
+"""MetaTrader 5 constant parsing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+_TIMEFRAME_ALIASES: Final[dict[str, int]] = {
+    "M1": 1,
+    "M2": 2,
+    "M3": 3,
+    "M4": 4,
+    "M5": 5,
+    "M6": 6,
+    "M10": 10,
+    "M12": 12,
+    "M15": 15,
+    "M20": 20,
+    "M30": 30,
+    "H1": 16385,
+    "H2": 16386,
+    "H3": 16387,
+    "H4": 16388,
+    "H6": 16390,
+    "H8": 16392,
+    "H12": 16396,
+    "D1": 16408,
+    "W1": 32769,
+    "MN1": 49153,
+}
+_COPY_TICKS_ALIASES: Final[dict[str, int]] = {
+    "INFO": 1,
+    "TRADE": 2,
+    "ALL": 3,
+}
+_ORDER_TYPE_ALIASES: Final[dict[str, int]] = {
+    "BUY": 0,
+    "SELL": 1,
+    "BUY_LIMIT": 2,
+    "SELL_LIMIT": 3,
+    "BUY_STOP": 4,
+    "SELL_STOP": 5,
+    "BUY_STOP_LIMIT": 6,
+    "SELL_STOP_LIMIT": 7,
+    "CLOSE_BY": 8,
+}
+
+_TIMEFRAME_OFFICIAL_NAMES: Final[tuple[str, ...]] = tuple(
+    f"TIMEFRAME_{name}" for name in _TIMEFRAME_ALIASES
+)
+_COPY_TICKS_OFFICIAL_NAMES: Final[tuple[str, ...]] = tuple(
+    f"COPY_TICKS_{name}" for name in _COPY_TICKS_ALIASES
+)
+_ORDER_TYPE_OFFICIAL_NAMES: Final[tuple[str, ...]] = tuple(
+    f"ORDER_TYPE_{name}" for name in _ORDER_TYPE_ALIASES
+)
+
+_TIMEFRAME_OFFICIAL_MAP: Final[dict[str, int]] = {
+    name: value
+    for name, value in zip(
+        _TIMEFRAME_OFFICIAL_NAMES,
+        _TIMEFRAME_ALIASES.values(),
+        strict=True,
+    )
+}
+_COPY_TICKS_OFFICIAL_MAP: Final[dict[str, int]] = {
+    name: value
+    for name, value in zip(
+        _COPY_TICKS_OFFICIAL_NAMES,
+        _COPY_TICKS_ALIASES.values(),
+        strict=True,
+    )
+}
+_ORDER_TYPE_OFFICIAL_MAP: Final[dict[str, int]] = {
+    name: value
+    for name, value in zip(
+        _ORDER_TYPE_OFFICIAL_NAMES,
+        _ORDER_TYPE_ALIASES.values(),
+        strict=True,
+    )
+}
+
+TIMEFRAME_MAP: Final[dict[str, int]] = {
+    **_TIMEFRAME_OFFICIAL_MAP,
+    **_TIMEFRAME_ALIASES,
+}
+COPY_TICKS_MAP: Final[dict[str, int]] = {
+    **_COPY_TICKS_OFFICIAL_MAP,
+    **_COPY_TICKS_ALIASES,
+}
+ORDER_TYPE_MAP: Final[dict[str, int]] = {
+    **_ORDER_TYPE_OFFICIAL_MAP,
+    **_ORDER_TYPE_ALIASES,
+}
+
+
+@dataclass(frozen=True)
+class _ConstantFamily:
+    """Metadata for one MT5 constant family."""
+
+    label: str
+    mapping: dict[str, int]
+    official_names: tuple[str, ...]
+    alias_names: tuple[str, ...]
+
+    @property
+    def values(self) -> list[int]:
+        """Return unique constant values in official MT5 order."""
+        return list(dict.fromkeys(self.mapping.values()))
+
+    @property
+    def value_set(self) -> set[int]:
+        """Return unique constant values for membership checks."""
+        return set(self.values)
+
+    def names(self, *, include_aliases: bool = True) -> list[str]:
+        """Return accepted constant names.
+
+        Args:
+            include_aliases: Include short aliases such as ``M1`` or ``BUY``.
+
+        Returns:
+            Accepted constant names in schema-friendly order.
+        """
+        names = list(self.official_names)
+        if include_aliases:
+            names.extend(self.alias_names)
+        return names
+
+    def name_by_value(self, value: int, *, prefer_alias: bool = False) -> str:
+        """Return the name for a constant value.
+
+        Args:
+            value: Integer constant value.
+            prefer_alias: Return the short alias instead of the official name.
+
+        Returns:
+            The matching constant name.
+
+        Raises:
+            ValueError: If the integer is not valid for this family.
+        """
+        parsed_value = _parse_constant(value, self)
+        names = self.alias_names if prefer_alias else self.official_names
+        value_map = {self.mapping[name]: name for name in names}
+        return value_map[parsed_value]
+
+
+_TIMEFRAME_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
+    label="MT5 timeframe",
+    mapping=TIMEFRAME_MAP,
+    official_names=_TIMEFRAME_OFFICIAL_NAMES,
+    alias_names=tuple(_TIMEFRAME_ALIASES),
+)
+_COPY_TICKS_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
+    label="MT5 COPY_TICKS flag",
+    mapping=COPY_TICKS_MAP,
+    official_names=_COPY_TICKS_OFFICIAL_NAMES,
+    alias_names=tuple(_COPY_TICKS_ALIASES),
+)
+_ORDER_TYPE_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
+    label="MT5 ORDER_TYPE",
+    mapping=ORDER_TYPE_MAP,
+    official_names=_ORDER_TYPE_OFFICIAL_NAMES,
+    alias_names=tuple(_ORDER_TYPE_ALIASES),
+)
+
+
+def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
+    """Parse a constant name or value for a family."""
+    if isinstance(value, str):
+        normalized_value = value.strip().upper()
+        if normalized_value in family.mapping:
+            return family.mapping[normalized_value]
+        try:
+            parsed_value = int(normalized_value)
+        except ValueError:
+            valid_names = ", ".join(family.names())
+            message = (
+                f"Invalid {family.label}: {value!r}. Use one of: {valid_names}, "
+                "or a valid integer value."
+            )
+            raise ValueError(message) from None
+    elif isinstance(value, bool) or not isinstance(value, int):
+        message = f"Invalid {family.label}: {value!r}. Use a name or integer value."
+        raise ValueError(message)
+    else:
+        parsed_value = value
+
+    if parsed_value not in family.value_set:
+        valid_values = ", ".join(str(v) for v in family.values)
+        message = (
+            f"Unsupported {family.label} value: {parsed_value}. "
+            f"Use one of: {valid_values}."
+        )
+        raise ValueError(message)
+    return parsed_value
+
+
+def parse_timeframe(value: int | str) -> int:
+    """Parse a MetaTrader 5 timeframe name, alias, or integer value.
+
+    Args:
+        value: Official name (``TIMEFRAME_M1``), short alias (``M1``), or integer
+            value.
+
+    Returns:
+        The validated MetaTrader 5 timeframe integer.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 timeframes.
+    """
+    return _parse_constant(value=value, family=_TIMEFRAME_FAMILY)
+
+
+def parse_copy_ticks(value: int | str) -> int:
+    """Parse a MetaTrader 5 COPY_TICKS name, alias, or integer value.
+
+    Args:
+        value: Official name (``COPY_TICKS_ALL``), short alias (``ALL``), or
+            integer value.
+
+    Returns:
+        The validated MetaTrader 5 COPY_TICKS integer.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 COPY_TICKS flags.
+    """
+    return _parse_constant(value=value, family=_COPY_TICKS_FAMILY)
+
+
+def parse_order_type(value: int | str) -> int:
+    """Parse a MetaTrader 5 ORDER_TYPE name, alias, or integer value.
+
+    Args:
+        value: Official name (``ORDER_TYPE_BUY``), short alias (``BUY``), or
+            integer value.
+
+    Returns:
+        The validated MetaTrader 5 ORDER_TYPE integer.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 order types.
+    """
+    return _parse_constant(value=value, family=_ORDER_TYPE_FAMILY)
+
+
+def list_timeframe_names(*, include_aliases: bool = True) -> list[str]:
+    """Return MT5 timeframe names for JSON schema generation.
+
+    Args:
+        include_aliases: Include short aliases such as ``M1``.
+
+    Returns:
+        Accepted timeframe names.
+    """
+    return _TIMEFRAME_FAMILY.names(include_aliases=include_aliases)
+
+
+def list_timeframe_values() -> list[int]:
+    """Return valid MT5 timeframe integer values for JSON schema generation.
+
+    Returns:
+        Valid timeframe integer values.
+    """
+    return _TIMEFRAME_FAMILY.values
+
+
+def get_timeframe_value(name: str) -> int:
+    """Return the integer value for an MT5 timeframe name or alias.
+
+    Args:
+        name: Official timeframe name or short alias.
+
+    Returns:
+        The matching timeframe integer.
+
+    Raises:
+        ValueError: If the name is not valid for MT5 timeframes.
+    """
+    return parse_timeframe(name)
+
+
+def get_timeframe_name(value: int, *, prefer_alias: bool = False) -> str:
+    """Return the MT5 timeframe name for an integer value.
+
+    Args:
+        value: Timeframe integer value.
+        prefer_alias: Return the short alias instead of the official name.
+
+    Returns:
+        The matching timeframe name.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 timeframes.
+    """
+    return _TIMEFRAME_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
+
+
+def list_copy_ticks_names(*, include_aliases: bool = True) -> list[str]:
+    """Return MT5 COPY_TICKS names for JSON schema generation.
+
+    Args:
+        include_aliases: Include short aliases such as ``ALL``.
+
+    Returns:
+        Accepted COPY_TICKS names.
+    """
+    return _COPY_TICKS_FAMILY.names(include_aliases=include_aliases)
+
+
+def list_copy_ticks_values() -> list[int]:
+    """Return valid MT5 COPY_TICKS integer values for JSON schema generation.
+
+    Returns:
+        Valid COPY_TICKS integer values.
+    """
+    return _COPY_TICKS_FAMILY.values
+
+
+def get_copy_ticks_value(name: str) -> int:
+    """Return the integer value for an MT5 COPY_TICKS name or alias.
+
+    Args:
+        name: Official COPY_TICKS name or short alias.
+
+    Returns:
+        The matching COPY_TICKS integer.
+
+    Raises:
+        ValueError: If the name is not valid for MT5 COPY_TICKS flags.
+    """
+    return parse_copy_ticks(name)
+
+
+def get_copy_ticks_name(value: int, *, prefer_alias: bool = False) -> str:
+    """Return the MT5 COPY_TICKS name for an integer value.
+
+    Args:
+        value: COPY_TICKS integer value.
+        prefer_alias: Return the short alias instead of the official name.
+
+    Returns:
+        The matching COPY_TICKS name.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 COPY_TICKS flags.
+    """
+    return _COPY_TICKS_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
+
+
+def list_order_type_names(*, include_aliases: bool = True) -> list[str]:
+    """Return MT5 ORDER_TYPE names for JSON schema generation.
+
+    Args:
+        include_aliases: Include short aliases such as ``BUY``.
+
+    Returns:
+        Accepted ORDER_TYPE names.
+    """
+    return _ORDER_TYPE_FAMILY.names(include_aliases=include_aliases)
+
+
+def list_order_type_values() -> list[int]:
+    """Return valid MT5 ORDER_TYPE integer values for JSON schema generation.
+
+    Returns:
+        Valid ORDER_TYPE integer values.
+    """
+    return _ORDER_TYPE_FAMILY.values
+
+
+def get_order_type_value(name: str) -> int:
+    """Return the integer value for an MT5 ORDER_TYPE name or alias.
+
+    Args:
+        name: Official ORDER_TYPE name or short alias.
+
+    Returns:
+        The matching ORDER_TYPE integer.
+
+    Raises:
+        ValueError: If the name is not valid for MT5 order types.
+    """
+    return parse_order_type(name)
+
+
+def get_order_type_name(value: int, *, prefer_alias: bool = False) -> str:
+    """Return the MT5 ORDER_TYPE name for an integer value.
+
+    Args:
+        value: ORDER_TYPE integer value.
+        prefer_alias: Return the short alias instead of the official name.
+
+    Returns:
+        The matching ORDER_TYPE name.
+
+    Raises:
+        ValueError: If the value is not valid for MT5 order types.
+    """
+    return _ORDER_TYPE_FAMILY.name_by_value(value=value, prefer_alias=prefer_alias)
+
+
+__all__ = [
+    "COPY_TICKS_MAP",
+    "ORDER_TYPE_MAP",
+    "TIMEFRAME_MAP",
+    "get_copy_ticks_name",
+    "get_copy_ticks_value",
+    "get_order_type_name",
+    "get_order_type_value",
+    "get_timeframe_name",
+    "get_timeframe_value",
+    "list_copy_ticks_names",
+    "list_copy_ticks_values",
+    "list_order_type_names",
+    "list_order_type_values",
+    "list_timeframe_names",
+    "list_timeframe_values",
+    "parse_copy_ticks",
+    "parse_order_type",
+    "parse_timeframe",
+]

--- a/pdmt5/constants.py
+++ b/pdmt5/constants.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 _TIMEFRAME_ALIASES: Final[dict[str, int]] = {
     "M1": 1,
@@ -77,18 +81,21 @@ _ORDER_TYPE_OFFICIAL_MAP: Final[dict[str, int]] = dict(
     )
 )
 
-TIMEFRAME_MAP: Final[dict[str, int]] = {
+_TIMEFRAME_MAP: Final[dict[str, int]] = {
     **_TIMEFRAME_OFFICIAL_MAP,
     **_TIMEFRAME_ALIASES,
 }
-COPY_TICKS_MAP: Final[dict[str, int]] = {
+_COPY_TICKS_MAP: Final[dict[str, int]] = {
     **_COPY_TICKS_OFFICIAL_MAP,
     **_COPY_TICKS_ALIASES,
 }
-ORDER_TYPE_MAP: Final[dict[str, int]] = {
+_ORDER_TYPE_MAP: Final[dict[str, int]] = {
     **_ORDER_TYPE_OFFICIAL_MAP,
     **_ORDER_TYPE_ALIASES,
 }
+TIMEFRAME_MAP: Final[Mapping[str, int]] = MappingProxyType(_TIMEFRAME_MAP)
+COPY_TICKS_MAP: Final[Mapping[str, int]] = MappingProxyType(_COPY_TICKS_MAP)
+ORDER_TYPE_MAP: Final[Mapping[str, int]] = MappingProxyType(_ORDER_TYPE_MAP)
 
 
 @dataclass(frozen=True)
@@ -96,7 +103,7 @@ class _ConstantFamily:
     """Metadata for one MT5 constant family."""
 
     label: str
-    mapping: dict[str, int]
+    mapping: Mapping[str, int]
     official_names: tuple[str, ...]
     alias_names: tuple[str, ...]
 
@@ -143,25 +150,25 @@ class _ConstantFamily:
 
 _TIMEFRAME_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
     label="MT5 timeframe",
-    mapping=TIMEFRAME_MAP,
+    mapping=_TIMEFRAME_MAP,
     official_names=_TIMEFRAME_OFFICIAL_NAMES,
     alias_names=tuple(_TIMEFRAME_ALIASES),
 )
 _COPY_TICKS_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
     label="MT5 COPY_TICKS flag",
-    mapping=COPY_TICKS_MAP,
+    mapping=_COPY_TICKS_MAP,
     official_names=_COPY_TICKS_OFFICIAL_NAMES,
     alias_names=tuple(_COPY_TICKS_ALIASES),
 )
 _ORDER_TYPE_FAMILY: Final[_ConstantFamily] = _ConstantFamily(
     label="MT5 ORDER_TYPE",
-    mapping=ORDER_TYPE_MAP,
+    mapping=_ORDER_TYPE_MAP,
     official_names=_ORDER_TYPE_OFFICIAL_NAMES,
     alias_names=tuple(_ORDER_TYPE_ALIASES),
 )
 
 
-def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
+def _parse_constant(value: object, family: _ConstantFamily) -> int:
     """Parse a constant name or value for a family.
 
     Args:
@@ -187,7 +194,7 @@ def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
                 "or a valid integer value."
             )
             raise ValueError(message) from None
-    elif isinstance(value, bool):
+    elif isinstance(value, bool) or not isinstance(value, int):
         message = f"Invalid {family.label}: {value!r}. Use a name or integer value."
         raise ValueError(message)  # noqa: TRY004
     else:
@@ -203,12 +210,12 @@ def _parse_constant(value: int | str, family: _ConstantFamily) -> int:
     return parsed_value
 
 
-def parse_timeframe(value: int | str) -> int:
+def parse_timeframe(value: object) -> int:
     """Parse a MetaTrader 5 timeframe name, alias, or integer value.
 
     Args:
-        value: Official name (``TIMEFRAME_M1``), short alias (``M1``), or integer
-            value.
+        value: Official name (``TIMEFRAME_M1``), short alias (``M1``), numeric
+            string, or integer value.
 
     Returns:
         The validated MetaTrader 5 timeframe integer.
@@ -217,12 +224,12 @@ def parse_timeframe(value: int | str) -> int:
     return _parse_constant(value=value, family=_TIMEFRAME_FAMILY)
 
 
-def parse_copy_ticks(value: int | str) -> int:
+def parse_copy_ticks(value: object) -> int:
     """Parse a MetaTrader 5 COPY_TICKS name, alias, or integer value.
 
     Args:
         value: Official name (``COPY_TICKS_ALL``), short alias (``ALL``), or
-            integer value.
+            numeric string, or integer value.
 
     Returns:
         The validated MetaTrader 5 COPY_TICKS integer.
@@ -231,12 +238,12 @@ def parse_copy_ticks(value: int | str) -> int:
     return _parse_constant(value=value, family=_COPY_TICKS_FAMILY)
 
 
-def parse_order_type(value: int | str) -> int:
+def parse_order_type(value: object) -> int:
     """Parse a MetaTrader 5 ORDER_TYPE name, alias, or integer value.
 
     Args:
         value: Official name (``ORDER_TYPE_BUY``), short alias (``BUY``), or
-            integer value.
+            numeric string, or integer value.
 
     Returns:
         The validated MetaTrader 5 ORDER_TYPE integer.

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ConfigDict
 
+from .constants import parse_copy_ticks, parse_order_type, parse_timeframe
 from .dataframe import Mt5DataClient
 from .mt5 import Mt5RuntimeError
 
@@ -257,7 +258,7 @@ class Mt5TradingClient(Mt5DataClient):
                 "action": self.mt5.TRADE_ACTION_DEAL,
                 "symbol": symbol,
                 "volume": volume,
-                "type": getattr(self.mt5, f"ORDER_TYPE_{order_side.upper()}"),
+                "type": parse_order_type(order_side),
                 "type_filling": getattr(
                     self.mt5, f"ORDER_FILLING_{order_filling_mode.upper()}"
                 ),
@@ -366,7 +367,7 @@ class Mt5TradingClient(Mt5DataClient):
         symbol_info = self.symbol_info_as_dict(symbol=symbol)
         symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
         margin = self.order_calc_margin(
-            action=getattr(self.mt5, f"ORDER_TYPE_{order_side.upper()}"),
+            action=parse_order_type(order_side),
             symbol=symbol,
             volume=symbol_info["volume_min"],
             price=(
@@ -470,8 +471,8 @@ class Mt5TradingClient(Mt5DataClient):
             Mt5TradingError: If the granularity is not supported by MetaTrader5.
         """
         try:
-            timeframe = getattr(self.mt5, f"TIMEFRAME_{granularity.upper()}")
-        except AttributeError as e:
+            timeframe = parse_timeframe(granularity)
+        except ValueError as e:
             error_message = (
                 f"MetaTrader5 does not support the given granularity: {granularity}"
             )
@@ -513,7 +514,7 @@ class Mt5TradingClient(Mt5DataClient):
             symbol=symbol,
             date_from=(last_tick_time - timedelta(seconds=seconds)),
             date_to=(last_tick_time + timedelta(seconds=seconds)),
-            flags=self.mt5.COPY_TICKS_ALL,
+            flags=parse_copy_ticks("ALL"),
             index_keys=index_keys,
         )
         logger.info(
@@ -580,13 +581,13 @@ class Mt5TradingClient(Mt5DataClient):
         else:
             symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
             ask_margin = self.order_calc_margin(
-                action=self.mt5.ORDER_TYPE_BUY,
+                action=parse_order_type("BUY"),
                 symbol=symbol,
                 volume=1,
                 price=symbol_info_tick["ask"],
             )
             bid_margin = self.order_calc_margin(
-                action=self.mt5.ORDER_TYPE_SELL,
+                action=parse_order_type("SELL"),
                 symbol=symbol,
                 volume=1,
                 price=symbol_info_tick["bid"],
@@ -659,14 +660,14 @@ class Mt5TradingClient(Mt5DataClient):
                 new_signed_margin = 0
             elif new_position_side.upper() == "BUY":
                 new_signed_margin = self.order_calc_margin(
-                    action=self.mt5.ORDER_TYPE_BUY,
+                    action=parse_order_type("BUY"),
                     symbol=symbol,
                     volume=new_position_volume,
                     price=symbol_info_tick["ask"],
                 )
             elif new_position_side.upper() == "SELL":
                 new_signed_margin = -self.order_calc_margin(
-                    action=self.mt5.ORDER_TYPE_SELL,
+                    action=parse_order_type("SELL"),
                     symbol=symbol,
                     volume=new_position_volume,
                     price=symbol_info_tick["bid"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.2.4"
+version = "0.3.0"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,249 @@
+"""Tests for pdmt5.constants module."""
+
+from collections.abc import Callable
+
+import pytest
+
+import pdmt5
+from pdmt5.constants import (
+    COPY_TICKS_MAP,
+    ORDER_TYPE_MAP,
+    TIMEFRAME_MAP,
+    get_copy_ticks_name,
+    get_copy_ticks_value,
+    get_order_type_name,
+    get_order_type_value,
+    get_timeframe_name,
+    get_timeframe_value,
+    list_copy_ticks_names,
+    list_copy_ticks_values,
+    list_order_type_names,
+    list_order_type_values,
+    list_timeframe_names,
+    list_timeframe_values,
+    parse_copy_ticks,
+    parse_order_type,
+    parse_timeframe,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("TIMEFRAME_M1", 1),
+        ("M1", 1),
+        ("timeframe_h1", 16385),
+        ("h1", 16385),
+        ("  TIMEFRAME_MN1  ", 49153),
+        ("49153", 49153),
+        (16408, 16408),
+    ],
+)
+def test_parse_timeframe_accepts_official_names_aliases_and_values(
+    value: int | str,
+    expected: int,
+) -> None:
+    """Test timeframe parsing for supported input forms."""
+    assert parse_timeframe(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("COPY_TICKS_ALL", 3),
+        ("ALL", 3),
+        ("copy_ticks_info", 1),
+        ("trade", 2),
+        ("2", 2),
+        (1, 1),
+    ],
+)
+def test_parse_copy_ticks_accepts_official_names_aliases_and_values(
+    value: int | str,
+    expected: int,
+) -> None:
+    """Test COPY_TICKS parsing for supported input forms."""
+    assert parse_copy_ticks(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("ORDER_TYPE_BUY", 0),
+        ("BUY", 0),
+        ("order_type_sell_limit", 3),
+        ("sell_stop_limit", 7),
+        ("8", 8),
+        (5, 5),
+    ],
+)
+def test_parse_order_type_accepts_official_names_aliases_and_values(
+    value: int | str,
+    expected: int,
+) -> None:
+    """Test ORDER_TYPE parsing for supported input forms."""
+    assert parse_order_type(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("parser", "value", "match"),
+    [
+        (parse_timeframe, "M7", "Invalid MT5 timeframe"),
+        (parse_timeframe, 8, "Unsupported MT5 timeframe value"),
+        (parse_timeframe, True, "Invalid MT5 timeframe"),
+        (parse_copy_ticks, "QUOTE", "Invalid MT5 COPY_TICKS flag"),
+        (parse_copy_ticks, 4, "Unsupported MT5 COPY_TICKS flag value"),
+        (parse_copy_ticks, False, "Invalid MT5 COPY_TICKS flag"),
+        (parse_order_type, "MARKET_BUY", "Invalid MT5 ORDER_TYPE"),
+        (parse_order_type, 9, "Unsupported MT5 ORDER_TYPE value"),
+        (parse_order_type, True, "Invalid MT5 ORDER_TYPE"),
+    ],
+)
+def test_parse_constants_reject_invalid_inputs(
+    parser: Callable[[int | str], int],
+    value: int | str,
+    match: str,
+) -> None:
+    """Test invalid names, invalid integers, and bool values are rejected."""
+    with pytest.raises(ValueError, match=match):
+        parser(value)
+
+
+def test_timeframe_helpers_return_schema_friendly_names_and_values() -> None:
+    """Test timeframe helper names and values for JSON schemas."""
+    assert TIMEFRAME_MAP["TIMEFRAME_M1"] == 1
+    assert TIMEFRAME_MAP["M1"] == 1
+    assert list_timeframe_names(include_aliases=False) == [
+        "TIMEFRAME_M1",
+        "TIMEFRAME_M2",
+        "TIMEFRAME_M3",
+        "TIMEFRAME_M4",
+        "TIMEFRAME_M5",
+        "TIMEFRAME_M6",
+        "TIMEFRAME_M10",
+        "TIMEFRAME_M12",
+        "TIMEFRAME_M15",
+        "TIMEFRAME_M20",
+        "TIMEFRAME_M30",
+        "TIMEFRAME_H1",
+        "TIMEFRAME_H2",
+        "TIMEFRAME_H3",
+        "TIMEFRAME_H4",
+        "TIMEFRAME_H6",
+        "TIMEFRAME_H8",
+        "TIMEFRAME_H12",
+        "TIMEFRAME_D1",
+        "TIMEFRAME_W1",
+        "TIMEFRAME_MN1",
+    ]
+    assert "M1" in list_timeframe_names()
+    assert list_timeframe_values() == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        10,
+        12,
+        15,
+        20,
+        30,
+        16385,
+        16386,
+        16387,
+        16388,
+        16390,
+        16392,
+        16396,
+        16408,
+        32769,
+        49153,
+    ]
+    assert get_timeframe_value("TIMEFRAME_H4") == 16388
+    assert get_timeframe_name(16388) == "TIMEFRAME_H4"
+    assert get_timeframe_name(16388, prefer_alias=True) == "H4"
+
+
+def test_copy_ticks_helpers_return_schema_friendly_names_and_values() -> None:
+    """Test COPY_TICKS helper names and values for JSON schemas."""
+    assert COPY_TICKS_MAP["COPY_TICKS_ALL"] == 3
+    assert COPY_TICKS_MAP["ALL"] == 3
+    assert list_copy_ticks_names(include_aliases=False) == [
+        "COPY_TICKS_INFO",
+        "COPY_TICKS_TRADE",
+        "COPY_TICKS_ALL",
+    ]
+    assert "ALL" in list_copy_ticks_names()
+    assert list_copy_ticks_values() == [1, 2, 3]
+    assert get_copy_ticks_value("COPY_TICKS_TRADE") == 2
+    assert get_copy_ticks_name(2) == "COPY_TICKS_TRADE"
+    assert get_copy_ticks_name(2, prefer_alias=True) == "TRADE"
+
+
+def test_order_type_helpers_return_schema_friendly_names_and_values() -> None:
+    """Test ORDER_TYPE helper names and values for JSON schemas."""
+    assert ORDER_TYPE_MAP["ORDER_TYPE_BUY"] == 0
+    assert ORDER_TYPE_MAP["BUY"] == 0
+    assert list_order_type_names(include_aliases=False) == [
+        "ORDER_TYPE_BUY",
+        "ORDER_TYPE_SELL",
+        "ORDER_TYPE_BUY_LIMIT",
+        "ORDER_TYPE_SELL_LIMIT",
+        "ORDER_TYPE_BUY_STOP",
+        "ORDER_TYPE_SELL_STOP",
+        "ORDER_TYPE_BUY_STOP_LIMIT",
+        "ORDER_TYPE_SELL_STOP_LIMIT",
+        "ORDER_TYPE_CLOSE_BY",
+    ]
+    assert "BUY" in list_order_type_names()
+    assert list_order_type_values() == [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    assert get_order_type_value("ORDER_TYPE_SELL_STOP") == 5
+    assert get_order_type_name(5) == "ORDER_TYPE_SELL_STOP"
+    assert get_order_type_name(5, prefer_alias=True) == "SELL_STOP"
+
+
+@pytest.mark.parametrize(
+    ("getter", "value"),
+    [
+        (get_timeframe_name, 7),
+        (get_copy_ticks_name, 4),
+        (get_order_type_name, 9),
+    ],
+)
+def test_name_helpers_reject_invalid_values(
+    getter: Callable[[int], str],
+    value: int,
+) -> None:
+    """Test name lookup helpers reject invalid integer constants."""
+    with pytest.raises(ValueError, match="Unsupported MT5"):
+        getter(value)
+
+
+@pytest.mark.parametrize(
+    "export",
+    [
+        "COPY_TICKS_MAP",
+        "ORDER_TYPE_MAP",
+        "TIMEFRAME_MAP",
+        "get_copy_ticks_name",
+        "get_copy_ticks_value",
+        "get_order_type_name",
+        "get_order_type_value",
+        "get_timeframe_name",
+        "get_timeframe_value",
+        "list_copy_ticks_names",
+        "list_copy_ticks_values",
+        "list_order_type_names",
+        "list_order_type_values",
+        "list_timeframe_names",
+        "list_timeframe_values",
+        "parse_copy_ticks",
+        "parse_order_type",
+        "parse_timeframe",
+    ],
+)
+def test_constants_exports_available(export: str) -> None:
+    """Test new public constants APIs are exported by pdmt5."""
+    assert hasattr(pdmt5, export), f"Missing export: {export}"
+    assert export in pdmt5.__all__, f"Export {export} not in __all__"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,8 +2,9 @@
 
 import importlib
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import ModuleType
+from typing import cast
 
 import pytest
 
@@ -105,17 +106,22 @@ def test_parse_order_type_accepts_official_names_aliases_and_values(
         (parse_timeframe, "M7", "Invalid MT5 timeframe"),
         (parse_timeframe, 8, "Unsupported MT5 timeframe value"),
         (parse_timeframe, True, "Invalid MT5 timeframe"),
+        (parse_timeframe, 1.0, "Invalid MT5 timeframe"),
+        (parse_timeframe, None, "Invalid MT5 timeframe"),
+        (parse_timeframe, object(), "Invalid MT5 timeframe"),
         (parse_copy_ticks, "QUOTE", "Invalid MT5 COPY_TICKS flag"),
         (parse_copy_ticks, 4, "Unsupported MT5 COPY_TICKS flag value"),
         (parse_copy_ticks, False, "Invalid MT5 COPY_TICKS flag"),
+        (parse_copy_ticks, 1.0, "Invalid MT5 COPY_TICKS flag"),
         (parse_order_type, "MARKET_BUY", "Invalid MT5 ORDER_TYPE"),
         (parse_order_type, 9, "Unsupported MT5 ORDER_TYPE value"),
         (parse_order_type, True, "Invalid MT5 ORDER_TYPE"),
+        (parse_order_type, 1.0, "Invalid MT5 ORDER_TYPE"),
     ],
 )
 def test_parse_constants_reject_invalid_inputs(
-    parser: Callable[[int | str], int],
-    value: int | str,
+    parser: Callable[[object], int],
+    value: object,
     match: str,
 ) -> None:
     """Test invalid names, invalid integers, and bool values are rejected."""
@@ -232,6 +238,30 @@ def test_name_helpers_reject_invalid_values(
     """Test name lookup helpers reject invalid integer constants."""
     with pytest.raises(ValueError, match="Unsupported MT5"):
         getter(value)
+
+
+@pytest.mark.parametrize(
+    ("constant_map", "key", "bad_value", "parser", "parser_value", "expected"),
+    [
+        (TIMEFRAME_MAP, "M1", 999, parse_timeframe, "M1", 1),
+        (COPY_TICKS_MAP, "ALL", 999, parse_copy_ticks, "ALL", -1),
+        (ORDER_TYPE_MAP, "BUY", 999, parse_order_type, "BUY", 0),
+    ],
+)
+def test_public_constant_maps_are_immutable_and_do_not_affect_parsers(
+    constant_map: Mapping[str, int],
+    key: str,
+    bad_value: int,
+    parser: Callable[[object], int],
+    parser_value: str,
+    expected: int,
+) -> None:
+    """Test exported maps cannot be mutated to change parser behavior."""
+    mutable_view = cast("dict[str, int]", constant_map)
+    with pytest.raises(TypeError):
+        mutable_view[key] = bad_value
+
+    assert parser(parser_value) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -64,8 +64,8 @@ def test_parse_timeframe_accepts_official_names_aliases_and_values(
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        ("COPY_TICKS_ALL", 3),
-        ("ALL", 3),
+        ("COPY_TICKS_ALL", -1),
+        ("ALL", -1),
         ("copy_ticks_info", 1),
         ("trade", 2),
         ("2", 2),
@@ -181,15 +181,15 @@ def test_timeframe_helpers_return_schema_friendly_names_and_values() -> None:
 
 def test_copy_ticks_helpers_return_schema_friendly_names_and_values() -> None:
     """Test COPY_TICKS helper names and values for JSON schemas."""
-    assert COPY_TICKS_MAP["COPY_TICKS_ALL"] == 3
-    assert COPY_TICKS_MAP["ALL"] == 3
+    assert COPY_TICKS_MAP["COPY_TICKS_ALL"] == -1
+    assert COPY_TICKS_MAP["ALL"] == -1
     assert list_copy_ticks_names(include_aliases=False) == [
         "COPY_TICKS_INFO",
         "COPY_TICKS_TRADE",
         "COPY_TICKS_ALL",
     ]
     assert "ALL" in list_copy_ticks_names()
-    assert list_copy_ticks_values() == [1, 2, 3]
+    assert list_copy_ticks_values() == [1, 2, -1]
     assert get_copy_ticks_value("COPY_TICKS_TRADE") == 2
     assert get_copy_ticks_name(2) == "COPY_TICKS_TRADE"
     assert get_copy_ticks_name(2, prefer_alias=True) == "TRADE"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,9 @@
 """Tests for pdmt5.constants module."""
 
+import importlib
+import sys
 from collections.abc import Callable
+from types import ModuleType
 
 import pytest
 
@@ -25,6 +28,17 @@ from pdmt5.constants import (
     parse_order_type,
     parse_timeframe,
 )
+
+_WINDOWS_ONLY = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="MetaTrader5 Python package is available only on Windows.",
+)
+
+
+@pytest.fixture(scope="module")
+def real_mt5_module() -> ModuleType:
+    """Import the real MetaTrader5 Python package for Windows parity tests."""
+    return importlib.import_module("MetaTrader5")
 
 
 @pytest.mark.parametrize(
@@ -247,3 +261,33 @@ def test_constants_exports_available(export: str) -> None:
     """Test new public constants APIs are exported by pdmt5."""
     assert hasattr(pdmt5, export), f"Missing export: {export}"
     assert export in pdmt5.__all__, f"Export {export} not in __all__"
+
+
+@_WINDOWS_ONLY
+@pytest.mark.parametrize("name", list_timeframe_names(include_aliases=False))
+def test_timeframe_constants_match_metatrader5_package(
+    real_mt5_module: ModuleType,
+    name: str,
+) -> None:
+    """Test pdmt5 timeframe constants match the real MetaTrader5 package."""
+    assert TIMEFRAME_MAP[name] == int(getattr(real_mt5_module, name))
+
+
+@_WINDOWS_ONLY
+@pytest.mark.parametrize("name", list_copy_ticks_names(include_aliases=False))
+def test_copy_ticks_constants_match_metatrader5_package(
+    real_mt5_module: ModuleType,
+    name: str,
+) -> None:
+    """Test pdmt5 COPY_TICKS constants match the real MetaTrader5 package."""
+    assert COPY_TICKS_MAP[name] == int(getattr(real_mt5_module, name))
+
+
+@_WINDOWS_ONLY
+@pytest.mark.parametrize("name", list_order_type_names(include_aliases=False))
+def test_order_type_constants_match_metatrader5_package(
+    real_mt5_module: ModuleType,
+    name: str,
+) -> None:
+    """Test pdmt5 ORDER_TYPE constants match the real MetaTrader5 package."""
+    assert ORDER_TYPE_MAP[name] == int(getattr(real_mt5_module, name))

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1182,7 +1182,7 @@ class TestMt5TradingClient:
         # Verify copy_ticks_range was called with correct arguments
         call_args = mock_mt5_import.copy_ticks_range.call_args[0]
         assert call_args[0] == "EURUSD"  # symbol
-        assert call_args[3] == 1  # flags (COPY_TICKS_ALL)
+        assert call_args[3] == 3  # flags (COPY_TICKS_ALL)
 
         # Verify result has the expected structure
         assert len(result) == 1

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1182,7 +1182,7 @@ class TestMt5TradingClient:
         # Verify copy_ticks_range was called with correct arguments
         call_args = mock_mt5_import.copy_ticks_range.call_args[0]
         assert call_args[0] == "EURUSD"  # symbol
-        assert call_args[3] == 3  # flags (COPY_TICKS_ALL)
+        assert call_args[3] == -1  # flags (COPY_TICKS_ALL)
 
         # Verify result has the expected structure
         assert len(result) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `pdmt5.constants` with public maps, parsers, and schema-friendly name/value helpers for TIMEFRAME, COPY_TICKS, and ORDER_TYPE constants.
- Export the constants API from `pdmt5` and use it in trading helpers for timeframe, tick flag, and order type parsing.
- Harden constant parsing to accept only strings and real integers, reject bool/float/None/arbitrary objects, and avoid equality edge cases.
- Expose public constant maps as immutable mapping proxies while parser internals use private maps.
- Document pdmt5 as the canonical MT5 constant parsing layer and add focused unit tests.
- Add Windows-only parity tests that compare pdmt5 official constant values against the real `MetaTrader5` Python package.
- Match the real package value for `COPY_TICKS_ALL` (`-1`).
- Bump package version metadata to `0.3.0`.

## Validation
- `python3 -m uv run ruff check .`
- `python3 -m uv run pyright`
- `python3 -m uv run pytest` (349 passed, 33 Windows-only skipped on Linux, 100% coverage)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f0dff3-3397-479f-be51-d494284cc375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f0dff3-3397-479f-be51-d494284cc375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

