### PR TITLE
Narrow Mt5TradingClient to core order primitives (#67)

### DIFF
--- a/.agents/skills/pr-feedback-triage/SKILL.md
+++ b/.agents/skills/pr-feedback-triage/SKILL.md
@@ -104,8 +104,8 @@ A reliable pattern is:
 Example GraphQL mutation shape:
 
 ```graphql
-mutation($threadId: ID!) {
-  resolveReviewThread(input: {threadId: $threadId}) {
+mutation ($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
     thread {
       id
       isResolved

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Pandas-based data handler for MetaTrader 5
 | HTTP adapter    | **mt5api**               | Sibling HTTP/FastAPI adapter that exposes `pdmt5` over a REST interface.                                                                                                                                                                                                                  |
 | Strategy apps   | _(downstream)_           | Signal generation, risk policy, backtesting, optimisation, and strategy-specific order decisions. These concerns belong in the application layer, not in `pdmt5` or `mt5cli`.                                                                                                             |
 
-`pdmt5` does **not** depend on `mt5cli`. `Mt5TradingClient` includes a set of
-higher-level convenience helpers retained for backward compatibility; see the
-[Mt5TradingClient](#mt5tradingclient) section for the classification of each method.
+`pdmt5` does **not** depend on `mt5cli`.
 
 ### Key Features
 
@@ -237,32 +235,21 @@ order_type_schema = {
 ### Mt5TradingClient
 
 Trading client that extends `Mt5DataClient` with direct order primitives and
-compatibility helpers. Methods are classified as follows:
+convenience wrappers. Methods are classified as follows:
 
 - **Core MT5 primitives** — thin wrappers or constant mappings directly over the
-  MetaTrader5 API. Always appropriate in `pdmt5`:
+  MetaTrader5 API:
   - `mt5_successful_trade_retcodes` — set of `TRADE_RETCODE_*` values indicating success
   - `mt5_failed_trade_retcodes` — set of `TRADE_RETCODE_*` values indicating failure
 
-- **Convenience wrappers** — slightly higher-level helpers that remain closely coupled
-  to a single MT5 call and are appropriate in `pdmt5`:
+- **Convenience wrappers** — slightly higher-level helpers closely coupled to a
+  single MT5 call:
   - `place_market_order()` — builds a `TRADE_ACTION_DEAL` request and sends/checks it
   - `calculate_minimum_order_margin()` — combines `symbol_info` + `order_calc_margin`
     to return the margin for the minimum allowable volume
   - `fetch_latest_rates_as_df()` — calls `copy_rates_from_pos_as_df` from position 0
     after resolving a `granularity` string (e.g. `"M1"`, `"H1"`) via `parse_timeframe`
   - `fetch_latest_ticks_as_df()` — calls `copy_ticks_range_as_df` centred on the last tick
-
-- **Compatibility helpers** — higher-level operational helpers retained for backward
-  compatibility. New downstream applications should implement this logic in
-  `mt5cli` or their own layer instead:
-  - `close_open_positions()` — orchestrates fetching and closing positions across symbols
-  - `update_sltp_for_open_positions()` — fetches, filters, and updates SL/TP for open positions
-  - `calculate_volume_by_margin()` — margin-budget volume sizing
-  - `calculate_spread_ratio()` — normalised bid-ask spread pre-check
-  - `collect_entry_deals_as_df()` — deal-history fetching with BUY/SELL entry filtering
-  - `fetch_positions_with_metrics_as_df()` — positions DataFrame augmented with derived metrics
-  - `calculate_new_position_margin_ratio()` — margin-utilisation ratio for a prospective position
 
 - **Error handling**: `Mt5TradingError` (extends `Mt5RuntimeError`) is raised when
   an order operation returns a failed retcode and `raise_on_error=True`.
@@ -340,16 +327,9 @@ with Mt5DataClient(config=config) as client:
 
 ### Trading Operations
 
-> **Note**: `place_market_order()` is a convenience wrapper appropriate in
-> `pdmt5`. Methods such as `close_open_positions()`, `update_sltp_for_open_positions()`,
-> `calculate_new_position_margin_ratio()`, and the market-analysis helpers below are
-> compatibility helpers retained for backward compatibility. New downstream
-> applications should implement this operational logic in `mt5cli` instead.
-
 ```python
 from pdmt5 import Mt5TradingClient
 
-# Create trading client
 with Mt5TradingClient(config=config) as trader:
     # Place a market buy order
     order_result = trader.place_market_order(
@@ -361,85 +341,30 @@ with Mt5TradingClient(config=config) as trader:
     )
     print(f"Order placed: {order_result['retcode']}")
 
-    # Update stop loss and take profit for open positions
-    update_results = trader.update_sltp_for_open_positions(
+    # Dry run: validate without executing
+    check_result = trader.place_market_order(
         symbol="EURUSD",
-        stop_loss=1.0950,   # New stop loss
-        take_profit=1.1050  # New take profit
+        volume=0.1,
+        order_side="SELL",
+        dry_run=True,
     )
-    for result in update_results:
-        print(f"Position updated: {result['retcode']}")
+    print(f"Check result: {check_result['retcode']}")
 
-    # Calculate margin ratio for a new position
-    margin_ratio = trader.calculate_new_position_margin_ratio(
-        symbol="EURUSD",
-        new_position_side="SELL",
-        new_position_volume=0.2
-    )
-    print(f"New position margin ratio: {margin_ratio:.2%}")
+    # Calculate minimum margin for a position
+    min_margin = trader.calculate_minimum_order_margin("EURUSD", "BUY")
+    print(f"Min volume: {min_margin['volume']}, min margin: {min_margin['margin']}")
 
-    # Close all EURUSD positions with specific order filling mode
-    results = trader.close_open_positions(
-        symbols="EURUSD",
-        order_filling_mode="FOK"  # Fill or Kill
-    )
-
-    if results:
-        for symbol, close_results in results.items():
-            for result in close_results:
-                print(f"Closed position {result.get('position')} with result: {result['retcode']}")
-```
-
-### Market Analysis with Mt5TradingClient
-
-```python
-with Mt5TradingClient(config=config) as trader:
-    # Calculate spread ratio for EURUSD
-    spread_ratio = trader.calculate_spread_ratio("EURUSD")
-    print(f"EURUSD spread ratio: {spread_ratio:.5f}")
-
-    # Get minimum order margin for BUY and SELL
-    buy_margin = trader.calculate_minimum_order_margin("EURUSD", "BUY")
-    sell_margin = trader.calculate_minimum_order_margin("EURUSD", "SELL")
-    print(f"Minimum BUY margin: {buy_margin['margin']} (volume: {buy_margin['volume']})")
-    print(f"Minimum SELL margin: {sell_margin['margin']} (volume: {sell_margin['volume']})")
-
-    # Calculate volume by margin
-    available_margin = 1000.0
-    max_buy_volume = trader.calculate_volume_by_margin("EURUSD", available_margin, "BUY")
-    max_sell_volume = trader.calculate_volume_by_margin("EURUSD", available_margin, "SELL")
-    print(f"Max BUY volume for ${available_margin}: {max_buy_volume}")
-    print(f"Max SELL volume for ${available_margin}: {max_sell_volume}")
-
-    # Get recent OHLC data with custom timeframe
+    # Fetch recent OHLC bars
     rates_df = trader.fetch_latest_rates_as_df(
         symbol="EURUSD",
-        granularity="M15",  # 15-minute bars
-        count=100
+        granularity="M15",
+        count=100,
     )
     print(rates_df.tail())
 
-    # Get tick data for the last 60 seconds
-    ticks_df = trader.fetch_latest_ticks_as_df(
-        symbol="EURUSD",
-        seconds=60
-    )
+    # Fetch recent tick data
+    ticks_df = trader.fetch_latest_ticks_as_df(symbol="EURUSD", seconds=60)
     print(f"Received {len(ticks_df)} ticks")
-
-    # Collect entry deals for the last hour
-    deals_df = trader.collect_entry_deals_as_df(
-        symbol="EURUSD",
-        history_seconds=3600
-    )
-    if not deals_df.empty:
-        print(f"Found {len(deals_df)} entry deals")
-        print(deals_df[['time', 'type', 'volume', 'price']].head())
-
-    # Get positions with calculated metrics
-    positions_df = trader.fetch_positions_with_metrics_as_df("EURUSD")
-    if not positions_df.empty:
-        print(f"Open positions with metrics:")
-        print(positions_df[['ticket', 'volume', 'profit', 'elapsed_seconds', 'underlier_profit_ratio']].head())
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -11,19 +11,6 @@ Pandas-based data handler for MetaTrader 5
 
 **pdmt5** is a Python package that provides a pandas-based interface for MetaTrader 5 (MT5), making it easier to work with financial market data in Python. It provides helpers to convert MT5's native data structures into pandas DataFrames and dictionaries, enabling seamless integration with data science workflows.
 
-### Ecosystem and Responsibility Boundary
-
-**pdmt5** sits at the core of a layered ecosystem:
-
-| Layer           | Package                  | Responsibility                                                                                                                                                                                                                                                                            |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Core adapter    | **pdmt5** (this package) | MT5 connection lifecycle, low-level MT5 method wrappers, DataFrame/dict conversion helpers, canonical MT5 constant parsing, minimal direct order primitives around `order_check` / `order_send`                                                                                           |
-| Operational SDK | **mt5cli**               | Canonical downstream operational SDK / CLI / batch processing / SQLite history layer built on top of `pdmt5`. Generic operational orchestration belongs here: margin-budget sizing, normalised execution-result handling, broker constraint pre-checks, and downstream trading workflows. |
-| HTTP adapter    | **mt5api**               | Sibling HTTP/FastAPI adapter that exposes `pdmt5` over a REST interface.                                                                                                                                                                                                                  |
-| Strategy apps   | _(downstream)_           | Signal generation, risk policy, backtesting, optimisation, and strategy-specific order decisions. These concerns belong in the application layer, not in `pdmt5` or `mt5cli`.                                                                                                             |
-
-`pdmt5` does **not** depend on `mt5cli`.
-
 ### Key Features
 
 - 📊 **Pandas Integration**: DataFrame and dictionary helpers for easy analysis

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ Pandas-based data handler for MetaTrader 5
 
 **pdmt5** is a Python package that provides a pandas-based interface for MetaTrader 5 (MT5), making it easier to work with financial market data in Python. It provides helpers to convert MT5's native data structures into pandas DataFrames and dictionaries, enabling seamless integration with data science workflows.
 
+### Ecosystem and Responsibility Boundary
+
+**pdmt5** sits at the core of a layered ecosystem:
+
+| Layer           | Package                  | Responsibility                                                                                                                                                                                                                                                                            |
+| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core adapter    | **pdmt5** (this package) | MT5 connection lifecycle, low-level MT5 method wrappers, DataFrame/dict conversion helpers, canonical MT5 constant parsing, minimal direct order primitives around `order_check` / `order_send`                                                                                           |
+| Operational SDK | **mt5cli**               | Canonical downstream operational SDK / CLI / batch processing / SQLite history layer built on top of `pdmt5`. Generic operational orchestration belongs here: margin-budget sizing, normalised execution-result handling, broker constraint pre-checks, and downstream trading workflows. |
+| HTTP adapter    | **mt5api**               | Sibling HTTP/FastAPI adapter that exposes `pdmt5` over a REST interface.                                                                                                                                                                                                                  |
+| Strategy apps   | _(downstream)_           | Signal generation, risk policy, backtesting, optimisation, and strategy-specific order decisions. These concerns belong in the application layer, not in `pdmt5` or `mt5cli`.                                                                                                             |
+
+`pdmt5` does **not** depend on `mt5cli`. `Mt5TradingClient` includes a set of
+higher-level convenience helpers retained for backward compatibility; see the
+[Mt5TradingClient](#mt5tradingclient) section for the classification of each method.
+
 ### Key Features
 
 - 📊 **Pandas Integration**: DataFrame and dictionary helpers for easy analysis
@@ -21,8 +36,8 @@ Pandas-based data handler for MetaTrader 5
 - 🚀 **Context Manager Support**: Clean initialization and cleanup with `with` statements (initialize only)
 - 📈 **Time Series Ready**: OHLCV data with proper datetime indexing
 - 🛡️ **Robust Error Handling**: Custom exceptions with detailed MT5 error information
-- 💰 **Advanced Trading Operations**: Position management, margin calculations, and risk analysis tools
-- 🧪 **Dry Run Mode**: Test trading strategies without executing real trades
+- 💰 **Direct Order Primitives**: `order_check` / `order_send` wrappers with retcode validation
+- 🧪 **Dry Run Mode**: Test order requests without executing real trades
 
 ## Requirements
 
@@ -221,27 +236,36 @@ order_type_schema = {
 
 ### Mt5TradingClient
 
-Advanced trading operations client that extends Mt5DataClient:
+Trading client that extends `Mt5DataClient` with direct order primitives and
+compatibility helpers. Methods are classified as follows:
 
-- **Position Management**:
-  - `close_open_positions()` - Close all positions for specified symbol(s)
-  - `place_market_order()` - Place market orders with configurable side, volume, and execution modes
-  - `update_sltp_for_open_positions()` - Modify stop loss and take profit levels for open positions
-- **Margin Calculations**:
-  - `calculate_minimum_order_margin()` - Calculate minimum required margin for a specific order side
-  - `calculate_volume_by_margin()` - Calculate maximum volume for given margin amount
-  - `calculate_spread_ratio()` - Calculate normalized bid-ask spread ratio
-  - `calculate_new_position_margin_ratio()` - Calculate margin ratio for potential new positions
-- **Simplified Data Access**:
-  - `fetch_latest_rates_as_df()` - Get recent OHLC data with timeframe strings (e.g., "M1", "H1", "D1")
-  - `fetch_latest_ticks_as_df()` - Get tick data for specified seconds around last tick
-  - `collect_entry_deals_as_df()` - Filter and collect entry deals (BUY/SELL) from history
-  - `fetch_positions_with_metrics_as_df()` - Get open positions with calculated metrics (elapsed time, margin, profit ratios)
-- **Features**:
-  - Smart order routing with configurable filling modes
-  - Comprehensive error handling with `Mt5TradingError`
-  - Support for batch operations on multiple symbols
-  - Automatic position closing with proper order type reversal
+- **Core MT5 primitives** — thin wrappers or constant mappings directly over the
+  MetaTrader5 API. Always appropriate in `pdmt5`:
+  - `mt5_successful_trade_retcodes` — set of `TRADE_RETCODE_*` values indicating success
+  - `mt5_failed_trade_retcodes` — set of `TRADE_RETCODE_*` values indicating failure
+
+- **Convenience wrappers** — slightly higher-level helpers that remain closely coupled
+  to a single MT5 call and are appropriate in `pdmt5`:
+  - `place_market_order()` — builds a `TRADE_ACTION_DEAL` request and sends/checks it
+  - `calculate_minimum_order_margin()` — combines `symbol_info` + `order_calc_margin`
+    to return the margin for the minimum allowable volume
+  - `fetch_latest_rates_as_df()` — calls `copy_rates_from_pos_as_df` from position 0
+    after resolving a `granularity` string (e.g. `"M1"`, `"H1"`) via `parse_timeframe`
+  - `fetch_latest_ticks_as_df()` — calls `copy_ticks_range_as_df` centred on the last tick
+
+- **Compatibility helpers** — higher-level operational helpers retained for backward
+  compatibility. New downstream applications should implement this logic in
+  `mt5cli` or their own layer instead:
+  - `close_open_positions()` — orchestrates fetching and closing positions across symbols
+  - `update_sltp_for_open_positions()` — fetches, filters, and updates SL/TP for open positions
+  - `calculate_volume_by_margin()` — margin-budget volume sizing
+  - `calculate_spread_ratio()` — normalised bid-ask spread pre-check
+  - `collect_entry_deals_as_df()` — deal-history fetching with BUY/SELL entry filtering
+  - `fetch_positions_with_metrics_as_df()` — positions DataFrame augmented with derived metrics
+  - `calculate_new_position_margin_ratio()` — margin-utilisation ratio for a prospective position
+
+- **Error handling**: `Mt5TradingError` (extends `Mt5RuntimeError`) is raised when
+  an order operation returns a failed retcode and `raise_on_error=True`.
 
 ### Configuration
 
@@ -315,6 +339,12 @@ with Mt5DataClient(config=config) as client:
 ```
 
 ### Trading Operations
+
+> **Note**: `place_market_order()` is a convenience wrapper appropriate in
+> `pdmt5`. Methods such as `close_open_positions()`, `update_sltp_for_open_positions()`,
+> `calculate_new_position_margin_ratio()`, and the market-analysis helpers below are
+> compatibility helpers retained for backward compatibility. New downstream
+> applications should implement this operational logic in `mt5cli` instead.
 
 ```python
 from pdmt5 import Mt5TradingClient

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -23,10 +23,9 @@ integer values.
 
 ### [Mt5TradingClient](trading.md)
 
-Direct order primitives around `order_check` / `order_send` and a set of
-compatibility helpers retained for backward compatibility. New downstream
-applications should implement higher-level operational trading logic in
-`mt5cli` rather than adding new usage of the compatibility helpers here.
+Direct order primitives around `order_check` / `order_send` and convenience
+wrappers for common single-call patterns. Higher-level operational orchestration
+belongs in `mt5cli`.
 
 ## Architecture Overview
 
@@ -34,7 +33,7 @@ applications should implement higher-level operational trading logic in
 
 1. **Base Layer** (`mt5.py`): `Mt5Client` — low-level MT5 API access and `Mt5RuntimeError`
 2. **Data Layer** (`dataframe.py`): `Mt5DataClient` / `Mt5Config` — pandas-friendly interface and configuration
-3. **Trading Layer** (`trading.py`): `Mt5TradingClient` — direct order primitives and backward-compatible helpers
+3. **Trading Layer** (`trading.py`): `Mt5TradingClient` — direct order primitives and convenience wrappers
 4. **Constants** (`constants.py`): Canonical MT5 constant parsing and schema helpers
 5. **Utilities** (`utils.py`): Time conversion and DataFrame helpers
 
@@ -43,12 +42,12 @@ applications should implement higher-level operational trading logic in
 `pdmt5` is the **core MT5 / pandas adapter** and does not depend on any
 downstream package. The table below shows where each concern belongs:
 
-| Layer | Package | Responsibility |
-|---|---|---|
-| Core adapter | **pdmt5** | MT5 lifecycle, low-level wrappers, DataFrame/dict helpers, constant parsing, minimal order primitives |
-| Operational SDK | **mt5cli** | Margin-budget sizing, normalised execution results, broker pre-checks, batch workflows, CLI, SQLite history |
-| HTTP adapter | **mt5api** | REST/FastAPI interface over `pdmt5` |
-| Strategy apps | *(downstream)* | Signal generation, risk policy, backtesting, optimisation, strategy-specific decisions |
+| Layer           | Package        | Responsibility                                                                                              |
+| --------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| Core adapter    | **pdmt5**      | MT5 lifecycle, low-level wrappers, DataFrame/dict helpers, constant parsing, minimal order primitives       |
+| Operational SDK | **mt5cli**     | Margin-budget sizing, normalised execution results, broker pre-checks, batch workflows, CLI, SQLite history |
+| HTTP adapter    | **mt5api**     | REST/FastAPI interface over `pdmt5`                                                                         |
+| Strategy apps   | _(downstream)_ | Signal generation, risk policy, backtesting, optimisation, strategy-specific decisions                      |
 
 ## Usage Guidelines
 
@@ -93,10 +92,10 @@ with Mt5DataClient(mt5=mt5, config=config) as client:
         "EURUSD", parse_timeframe("H1"), datetime.now(), 100
     )
 
-# Advanced trading operations with Mt5TradingClient
+# Direct order primitives with Mt5TradingClient
 with Mt5TradingClient(mt5=mt5, config=config) as client:
-    # Close all positions for a symbol
-    results = client.close_open_positions("EURUSD", dry_run=True)
+    # Place a market order (dry-run validates without executing)
+    result = client.place_market_order("EURUSD", 0.1, "BUY", dry_run=True)
 
 # Schema-friendly MT5 constant metadata
 timeframe_names = list_timeframe_names()

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -23,17 +23,32 @@ integer values.
 
 ### [Mt5TradingClient](trading.md)
 
-Advanced trading operations including position management, order analysis, and trading performance metrics with dry run support.
+Direct order primitives around `order_check` / `order_send` and a set of
+compatibility helpers retained for backward compatibility. New downstream
+applications should implement higher-level operational trading logic in
+`mt5cli` rather than adding new usage of the compatibility helpers here.
 
 ## Architecture Overview
 
-The package follows a layered architecture:
+### Internal package layers
 
-1. **Base Layer** (`mt5.py`): Provides the base `Mt5Client` class with low-level MT5 API access and `Mt5RuntimeError` exception
-2. **Data Layer** (`dataframe.py`): Extends `Mt5Client` with configuration (`Mt5Config`) and pandas-friendly `Mt5DataClient` class
-3. **Trading Layer** (`trading.py`): Extends `Mt5DataClient` with advanced trading operations and `Mt5TradingError` exception
-4. **Constants** (`constants.py`): Shared MT5 constant parsing and schema helper values
-5. **Utilities** (`utils.py`): Helper functions for time conversion and DataFrame manipulation
+1. **Base Layer** (`mt5.py`): `Mt5Client` — low-level MT5 API access and `Mt5RuntimeError`
+2. **Data Layer** (`dataframe.py`): `Mt5DataClient` / `Mt5Config` — pandas-friendly interface and configuration
+3. **Trading Layer** (`trading.py`): `Mt5TradingClient` — direct order primitives and backward-compatible helpers
+4. **Constants** (`constants.py`): Canonical MT5 constant parsing and schema helpers
+5. **Utilities** (`utils.py`): Time conversion and DataFrame helpers
+
+### Ecosystem boundary
+
+`pdmt5` is the **core MT5 / pandas adapter** and does not depend on any
+downstream package. The table below shows where each concern belongs:
+
+| Layer | Package | Responsibility |
+|---|---|---|
+| Core adapter | **pdmt5** | MT5 lifecycle, low-level wrappers, DataFrame/dict helpers, constant parsing, minimal order primitives |
+| Operational SDK | **mt5cli** | Margin-budget sizing, normalised execution results, broker pre-checks, batch workflows, CLI, SQLite history |
+| HTTP adapter | **mt5api** | REST/FastAPI interface over `pdmt5` |
+| Strategy apps | *(downstream)* | Signal generation, risk policy, backtesting, optimisation, strategy-specific decisions |
 
 ## Usage Guidelines
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,8 +24,7 @@ integer values.
 ### [Mt5TradingClient](trading.md)
 
 Direct order primitives around `order_check` / `order_send` and convenience
-wrappers for common single-call patterns. Higher-level operational orchestration
-belongs in `mt5cli`.
+wrappers for common single-call patterns.
 
 ## Architecture Overview
 
@@ -36,18 +35,6 @@ belongs in `mt5cli`.
 3. **Trading Layer** (`trading.py`): `Mt5TradingClient` — direct order primitives and convenience wrappers
 4. **Constants** (`constants.py`): Canonical MT5 constant parsing and schema helpers
 5. **Utilities** (`utils.py`): Time conversion and DataFrame helpers
-
-### Ecosystem boundary
-
-`pdmt5` is the **core MT5 / pandas adapter** and does not depend on any
-downstream package. The table below shows where each concern belongs:
-
-| Layer           | Package        | Responsibility                                                                                              |
-| --------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
-| Core adapter    | **pdmt5**      | MT5 lifecycle, low-level wrappers, DataFrame/dict helpers, constant parsing, minimal order primitives       |
-| Operational SDK | **mt5cli**     | Margin-budget sizing, normalised execution results, broker pre-checks, batch workflows, CLI, SQLite history |
-| HTTP adapter    | **mt5api**     | REST/FastAPI interface over `pdmt5`                                                                         |
-| Strategy apps   | _(downstream)_ | Signal generation, risk policy, backtesting, optimisation, strategy-specific decisions                      |
 
 ## Usage Guidelines
 

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -4,7 +4,38 @@
 
 ## Overview
 
-The trading module extends Mt5DataClient with advanced trading operations including position management, order execution, and dry run support for testing trading strategies without actual execution.
+The trading module extends `Mt5DataClient` with direct order primitives around
+`order_check` / `order_send` and a set of compatibility helpers retained from
+earlier versions of the library.
+
+### Responsibility boundary
+
+`pdmt5` is the **core MT5 / pandas adapter**. Its scope covers the MT5 connection
+lifecycle, low-level MT5 method wrappers, DataFrame / dict conversion helpers,
+canonical MT5 constant parsing, and minimal direct order primitives.
+
+Generic operational orchestration — margin-budget sizing, normalised
+execution-result handling, broker constraint pre-checks, and downstream trading
+workflows — belongs in **`mt5cli`**, the canonical downstream operational SDK /
+CLI / batch / SQLite history layer built on top of `pdmt5`.
+
+`mt5api` is the sibling HTTP/FastAPI adapter that exposes `pdmt5` over a REST
+interface. Downstream strategy applications own signal generation, risk policy,
+backtesting, optimisation, and strategy-specific order decisions.
+
+### Method classification
+
+Methods in `Mt5TradingClient` fall into three categories:
+
+- **Core MT5 primitive**: thin wrapper or constant mapping directly over the
+  MetaTrader5 Python API. Always appropriate in `pdmt5`.
+- **Convenience wrapper**: slightly higher-level helper that remains closely
+  coupled to a single MT5 call and is appropriate in `pdmt5`.
+- **Compatibility helper**: higher-level operational helper retained for backward
+  compatibility. New downstream applications should implement this logic in
+  `mt5cli` or their own layer instead.
+
+See the docstring of each method for its individual classification.
 
 ## Classes
 
@@ -14,7 +45,14 @@ The trading module extends Mt5DataClient with advanced trading operations includ
 options:
 show_bases: false
 
-Advanced trading client class that inherits from `Mt5DataClient` and provides specialized trading functionality.
+Trading client that extends `Mt5DataClient` with direct order primitives
+(`place_market_order`, `_send_or_check_order`) and compatibility helpers
+retained for backward compatibility (`close_open_positions`,
+`update_sltp_for_open_positions`, `calculate_volume_by_margin`,
+`calculate_spread_ratio`, `collect_entry_deals_as_df`,
+`fetch_positions_with_metrics_as_df`, `calculate_new_position_margin_ratio`).
+New downstream applications should implement the compatibility-helper logic in
+`mt5cli` rather than adding new usage of those methods here.
 
 ### Mt5TradingError
 
@@ -132,11 +170,15 @@ with client:
 
 ## Position Management Features
 
-The Mt5TradingClient provides intelligent position management:
+`close_open_positions` and `update_sltp_for_open_positions` are **compatibility
+helpers** retained for backward compatibility. New downstream applications
+should implement position-management workflows in `mt5cli` instead.
 
-- **Automatic Position Reversal**: Automatically determines the correct order type to close positions
+The helpers provide:
+
+- **Automatic Position Reversal**: Determines the correct order type to close positions
 - **Batch Operations**: Close multiple positions for one or more symbols
-- **Dry Run Support**: Test trading logic without executing real trades
+- **Dry Run Support**: Validate orders via `order_check` without executing real trades
 - **Flexible Filtering**: Close positions by symbol(s) or all positions
 - **Custom Parameters**: Support for additional order parameters like comment, deviation, etc.
 
@@ -203,7 +245,11 @@ The `close_open_positions()` method returns a dictionary with symbols as keys:
 
 ## Margin Calculation Methods
 
-The trading client provides advanced margin calculation capabilities:
+`calculate_minimum_order_margin` is a **convenience wrapper** over
+`order_calc_margin` and is appropriate in `pdmt5`. `calculate_volume_by_margin`
+and `calculate_new_position_margin_ratio` are **compatibility helpers** retained
+for backward compatibility; new downstream applications should implement
+margin-budget logic in `mt5cli` instead.
 
 ### Calculate Minimum Order Margin
 
@@ -301,6 +347,12 @@ with client:
 ```
 
 ## Market Data and Analysis Methods
+
+`fetch_latest_rates_as_df` and `fetch_latest_ticks_as_df` are **convenience
+wrappers** appropriate in `pdmt5`. `calculate_spread_ratio`,
+`collect_entry_deals_as_df`, and `fetch_positions_with_metrics_as_df` are
+**compatibility helpers** retained for backward compatibility; new downstream
+applications should implement this logic in `mt5cli` instead.
 
 ### Spread Analysis
 

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -5,8 +5,7 @@
 ## Overview
 
 The trading module extends `Mt5DataClient` with direct order primitives around
-`order_check` / `order_send` and a set of compatibility helpers retained from
-earlier versions of the library.
+`order_check` / `order_send` and convenience wrappers for common single-call patterns.
 
 ### Responsibility boundary
 
@@ -25,15 +24,12 @@ backtesting, optimisation, and strategy-specific order decisions.
 
 ### Method classification
 
-Methods in `Mt5TradingClient` fall into three categories:
+Methods in `Mt5TradingClient` fall into two categories:
 
 - **Core MT5 primitive**: thin wrapper or constant mapping directly over the
   MetaTrader5 Python API. Always appropriate in `pdmt5`.
 - **Convenience wrapper**: slightly higher-level helper that remains closely
   coupled to a single MT5 call and is appropriate in `pdmt5`.
-- **Compatibility helper**: higher-level operational helper retained for backward
-  compatibility. New downstream applications should implement this logic in
-  `mt5cli` or their own layer instead.
 
 See the docstring of each method for its individual classification.
 
@@ -46,13 +42,10 @@ options:
 show_bases: false
 
 Trading client that extends `Mt5DataClient` with direct order primitives
-(`place_market_order`, `_send_or_check_order`) and compatibility helpers
-retained for backward compatibility (`close_open_positions`,
-`update_sltp_for_open_positions`, `calculate_volume_by_margin`,
-`calculate_spread_ratio`, `collect_entry_deals_as_df`,
-`fetch_positions_with_metrics_as_df`, `calculate_new_position_margin_ratio`).
-New downstream applications should implement the compatibility-helper logic in
-`mt5cli` rather than adding new usage of those methods here.
+(`place_market_order`, `_send_or_check_order`) and convenience wrappers
+(`calculate_minimum_order_margin`, `fetch_latest_rates_as_df`,
+`fetch_latest_ticks_as_df`). Higher-level operational orchestration belongs in
+`mt5cli`.
 
 ### Mt5TradingError
 
@@ -64,12 +57,13 @@ Custom runtime exception for trading-specific errors.
 
 ## Usage Examples
 
-### Basic Trading Operations
+### Market Order Placement
+
+Place market orders with flexible configuration:
 
 ```python
 from pdmt5 import Mt5TradingClient, Mt5Config
 
-# Create configuration
 config = Mt5Config(
     login=123456,
     password="your_password",
@@ -77,229 +71,7 @@ config = Mt5Config(
     timeout=60000,
 )
 
-# Create client
-client = Mt5TradingClient(config=config)
-
-# Use as context manager
-with client:
-    # Get current positions as DataFrame
-    positions_df = client.positions_get_as_df()
-    print(f"Open positions: {len(positions_df)}")
-
-    # Close positions for specific symbol
-    results = client.close_open_positions("EURUSD", dry_run=True)
-    print(f"Closed positions: {results}")
-```
-
-### Production Trading
-
-```python
-# Create client for live trading (default execution)
-client = Mt5TradingClient(config=config)
-
-with client:
-    # Close all positions for multiple symbols
-    results = client.close_open_positions(["EURUSD", "GBPUSD", "USDJPY"])
-
-    # Close all positions (all symbols)
-    all_results = client.close_open_positions()
-```
-
-### Order Filling Modes
-
-```python
 with Mt5TradingClient(config=config) as client:
-    # Use IOC (Immediate or Cancel) - default
-    results_ioc = client.close_open_positions(
-        symbols="EURUSD",
-        order_filling_mode="IOC"
-    )
-
-    # Use FOK (Fill or Kill)
-    results_fok = client.close_open_positions(
-        symbols="GBPUSD",
-        order_filling_mode="FOK"
-    )
-
-    # Use RETURN (Return if not filled)
-    results_return = client.close_open_positions(
-        symbols="USDJPY",
-        order_filling_mode="RETURN"
-    )
-```
-
-### Custom Order Parameters
-
-```python
-with client:
-    # Close positions with custom parameters and order filling mode
-    results = client.close_open_positions(
-        "EURUSD",
-        order_filling_mode="IOC",  # Specify per method call
-        comment="Closing all EURUSD positions",
-        deviation=10  # Maximum price deviation
-    )
-```
-
-### Error Handling
-
-```python
-from pdmt5.trading import Mt5TradingError
-
-try:
-    with client:
-        results = client.close_open_positions("EURUSD")
-except Mt5TradingError as e:
-    print(f"Trading error: {e}")
-    # Handle specific trading errors
-```
-
-### Checking Order Status
-
-```python
-with client:
-    # Check order (note: send_or_check_order is an internal method)
-    # For trading operations, use the provided methods like close_open_positions
-
-    # Example: Check if we can close a position
-    positions = client.positions_get_as_df()
-    if not positions.empty:
-        # Close specific position
-        results = client.close_open_positions("EURUSD")
-```
-
-## Position Management Features
-
-`close_open_positions` and `update_sltp_for_open_positions` are **compatibility
-helpers** retained for backward compatibility. New downstream applications
-should implement position-management workflows in `mt5cli` instead.
-
-The helpers provide:
-
-- **Automatic Position Reversal**: Determines the correct order type to close positions
-- **Batch Operations**: Close multiple positions for one or more symbols
-- **Dry Run Support**: Validate orders via `order_check` without executing real trades
-- **Flexible Filtering**: Close positions by symbol(s) or all positions
-- **Custom Parameters**: Support for additional order parameters like comment, deviation, etc.
-
-## Dry Run Mode
-
-Dry run mode is essential for testing trading strategies:
-
-```python
-# Test mode - validates orders without execution
-test_client = Mt5TradingClient(config=config)
-
-with test_client:
-    _ = test_client.close_open_positions("EURUSD", dry_run=True)
-
-# Production mode - executes real orders (default)
-prod_client = Mt5TradingClient(config=config)
-```
-
-In dry run mode:
-
-- Orders are validated using `order_check()` instead of `order_send()`
-- No actual trades are executed
-- Full validation of margin requirements and order parameters
-- Same return structure as live trading for easy testing
-
-## Return Values
-
-The `close_open_positions()` method returns a dictionary with symbols as keys:
-
-```python
-{
-    "EURUSD": [
-        {
-            "retcode": 10009,  # Trade done
-            "deal": 123456,
-            "order": 789012,
-            "volume": 1.0,
-            "price": 1.1000,
-            "comment": "Request executed",
-            ...
-        }
-    ],
-    "GBPUSD": [...]
-}
-```
-
-## Best Practices
-
-1. **Always use dry run mode first** to test your trading logic
-2. **Handle Mt5TradingError exceptions** for proper error management
-3. **Check return codes** to verify successful execution
-4. **Use context managers** for automatic connection handling
-5. **Log trading operations** for audit trails
-6. **Validate positions exist** before attempting to close them
-7. **Consider market hours** and trading session times
-
-## Common Return Codes
-
-- `TRADE_RETCODE_DONE` (10009): Trade operation completed successfully
-- `TRADE_RETCODE_TRADE_DISABLED`: Trading disabled for the account
-- `TRADE_RETCODE_MARKET_CLOSED`: Market is closed
-- `TRADE_RETCODE_NO_MONEY`: Insufficient funds
-- `TRADE_RETCODE_INVALID_VOLUME`: Invalid trade volume
-
-## Margin Calculation Methods
-
-`calculate_minimum_order_margin` is a **convenience wrapper** over
-`order_calc_margin` and is appropriate in `pdmt5`. `calculate_volume_by_margin`
-and `calculate_new_position_margin_ratio` are **compatibility helpers** retained
-for backward compatibility; new downstream applications should implement
-margin-budget logic in `mt5cli` instead.
-
-### Calculate Minimum Order Margin
-
-```python
-with client:
-    # Calculate minimum margin required for BUY order
-    min_margin_buy = client.calculate_minimum_order_margin("EURUSD", "BUY")
-    print(f"Minimum volume: {min_margin_buy['volume']}")
-    print(f"Minimum margin: {min_margin_buy['margin']}")
-
-    # Calculate minimum margin required for SELL order
-    min_margin_sell = client.calculate_minimum_order_margin("EURUSD", "SELL")
-```
-
-### Calculate Volume by Margin
-
-```python
-with client:
-    # Calculate maximum volume for given margin amount
-    available_margin = 1000.0  # USD
-    max_volume_buy = client.calculate_volume_by_margin("EURUSD", available_margin, "BUY")
-    max_volume_sell = client.calculate_volume_by_margin("EURUSD", available_margin, "SELL")
-
-    print(f"Max BUY volume for ${available_margin}: {max_volume_buy}")
-    print(f"Max SELL volume for ${available_margin}: {max_volume_sell}")
-```
-
-### Calculate New Position Margin Ratio
-
-```python
-with client:
-    # Calculate margin ratio for potential new position
-    margin_ratio = client.calculate_new_position_margin_ratio(
-        symbol="EURUSD",
-        new_position_side="BUY",
-        new_position_volume=1.0
-    )
-    print(f"New position would use {margin_ratio:.2%} of account equity")
-
-    # Check if adding position would exceed risk limits
-    if margin_ratio > 0.1:  # 10% risk limit
-        print("Position size too large for risk management")
-```
-
-## Market Order Placement
-
-Place market orders with flexible configuration:
-
-```python
-with client:
     # Place a BUY market order
     result = client.place_market_order(
         symbol="EURUSD",
@@ -323,50 +95,74 @@ with client:
     print(f"Order result: {result}")
 ```
 
-## Stop Loss and Take Profit Management
-
-Update SL/TP for existing positions:
+### Error Handling
 
 ```python
-with client:
-    # Update SL/TP for all EURUSD positions
-    results = client.update_sltp_for_open_positions(
-        symbol="EURUSD",
-        stop_loss=1.0950,
-        take_profit=1.1100,
-        dry_run=False
-    )
+from pdmt5.trading import Mt5TradingError
 
-    # Update only specific positions by ticket
-    results = client.update_sltp_for_open_positions(
+try:
+    with Mt5TradingClient(config=config) as client:
+        result = client.place_market_order("EURUSD", 1.0, "BUY", raise_on_error=True)
+except Mt5TradingError as e:
+    print(f"Trading error: {e}")
+```
+
+## Dry Run Mode
+
+Dry run mode validates orders without executing real trades:
+
+```python
+with Mt5TradingClient(config=config) as client:
+    # Validates the order request via order_check() without sending it
+    result = client.place_market_order(
         symbol="EURUSD",
-        stop_loss=1.0950,
-        tickets=[123456, 789012],  # Specific position tickets
-        dry_run=True
+        volume=0.1,
+        order_side="BUY",
+        dry_run=True,
     )
 ```
 
-## Market Data and Analysis Methods
+In dry run mode:
+
+- Orders are validated using `order_check()` instead of `order_send()`
+- No actual trades are executed
+- Full validation of margin requirements and order parameters
+- Same return structure as live trading for easy testing
+
+## Common Return Codes
+
+- `TRADE_RETCODE_DONE` (10009): Trade operation completed successfully
+- `TRADE_RETCODE_TRADE_DISABLED`: Trading disabled for the account
+- `TRADE_RETCODE_MARKET_CLOSED`: Market is closed
+- `TRADE_RETCODE_NO_MONEY`: Insufficient funds
+- `TRADE_RETCODE_INVALID_VOLUME`: Invalid trade volume
+
+## Margin Calculation
+
+`calculate_minimum_order_margin` is a **convenience wrapper** over
+`order_calc_margin` that returns the margin required for the broker's minimum
+allowable volume.
+
+```python
+with Mt5TradingClient(config=config) as client:
+    # Calculate minimum margin required for BUY order
+    min_margin_buy = client.calculate_minimum_order_margin("EURUSD", "BUY")
+    print(f"Minimum volume: {min_margin_buy['volume']}")
+    print(f"Minimum margin: {min_margin_buy['margin']}")
+
+    # Calculate minimum margin required for SELL order
+    min_margin_sell = client.calculate_minimum_order_margin("EURUSD", "SELL")
+```
+
+## Market Data Methods
 
 `fetch_latest_rates_as_df` and `fetch_latest_ticks_as_df` are **convenience
-wrappers** appropriate in `pdmt5`. `calculate_spread_ratio`,
-`collect_entry_deals_as_df`, and `fetch_positions_with_metrics_as_df` are
-**compatibility helpers** retained for backward compatibility; new downstream
-applications should implement this logic in `mt5cli` instead.
-
-### Spread Analysis
-
-```python
-with client:
-    # Calculate spread ratio for symbol
-    spread_ratio = client.calculate_spread_ratio("EURUSD")
-    print(f"EURUSD spread ratio: {spread_ratio:.6f}")
-```
+wrappers** appropriate in `pdmt5`.
 
 ### OHLC Data Retrieval
 
 ```python
-with client:
+with Mt5TradingClient(config=config) as client:
     # Fetch latest rate data as DataFrame
     rates_df = client.fetch_latest_rates_as_df(
         symbol="EURUSD",
@@ -380,7 +176,7 @@ with client:
 ### Tick Data Analysis
 
 ```python
-with client:
+with Mt5TradingClient(config=config) as client:
     # Fetch recent tick data
     ticks_df = client.fetch_latest_ticks_as_df(
         symbol="EURUSD",
@@ -388,65 +184,4 @@ with client:
         index_keys="time_msc"
     )
     print(f"Tick count: {len(ticks_df)}")
-```
-
-### Position Analytics with Enhanced Metrics
-
-```python
-with client:
-    # Get positions with additional calculated metrics
-    positions_df = client.fetch_positions_with_metrics_as_df("EURUSD")
-
-    if not positions_df.empty:
-        print("Position metrics:")
-        print(f"Total signed volume: {positions_df['signed_volume'].sum()}")
-        print(f"Total signed margin: {positions_df['signed_margin'].sum()}")
-        print(f"Average profit ratio: {positions_df['underlier_profit_ratio'].mean():.4f}")
-```
-
-### Deal History Analysis
-
-```python
-with client:
-    # Collect entry deals for analysis
-    deals_df = client.collect_entry_deals_as_df(
-        symbol="EURUSD",
-        history_seconds=3600,  # Last hour
-        index_keys="ticket"
-    )
-
-    if not deals_df.empty:
-        print(f"Entry deals found: {len(deals_df)}")
-        print(f"Deal types: {deals_df['type'].value_counts()}")
-```
-
-## Integration with Mt5DataClient
-
-Since Mt5TradingClient inherits from Mt5DataClient, all data retrieval methods are available:
-
-```python
-with Mt5TradingClient(config=config) as client:
-    # Get current positions as DataFrame
-    positions_df = client.positions_get_as_df()
-
-    # Analyze positions
-    if not positions_df.empty:
-        # Calculate total exposure
-        total_volume = positions_df['volume'].sum()
-
-        # Close losing positions
-        losing_positions = positions_df[positions_df['profit'] < 0]
-        for symbol in losing_positions['symbol'].unique():
-            client.close_open_positions(symbol)
-
-    # Risk management with margin calculations
-    for symbol in ["EURUSD", "GBPUSD", "USDJPY"]:
-        # Calculate current margin usage
-        current_ratio = client.calculate_new_position_margin_ratio(symbol)
-        print(f"{symbol} current margin ratio: {current_ratio:.2%}")
-
-        # Calculate maximum safe position size
-        safe_margin = 500.0  # USD
-        max_safe_volume = client.calculate_volume_by_margin(symbol, safe_margin, "BUY")
-        print(f"{symbol} max safe volume: {max_safe_volume}")
 ```

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -7,21 +7,6 @@
 The trading module extends `Mt5DataClient` with direct order primitives around
 `order_check` / `order_send` and convenience wrappers for common single-call patterns.
 
-### Responsibility boundary
-
-`pdmt5` is the **core MT5 / pandas adapter**. Its scope covers the MT5 connection
-lifecycle, low-level MT5 method wrappers, DataFrame / dict conversion helpers,
-canonical MT5 constant parsing, and minimal direct order primitives.
-
-Generic operational orchestration — margin-budget sizing, normalised
-execution-result handling, broker constraint pre-checks, and downstream trading
-workflows — belongs in **`mt5cli`**, the canonical downstream operational SDK /
-CLI / batch / SQLite history layer built on top of `pdmt5`.
-
-`mt5api` is the sibling HTTP/FastAPI adapter that exposes `pdmt5` over a REST
-interface. Downstream strategy applications own signal generation, risk policy,
-backtesting, optimisation, and strategy-specific order decisions.
-
 ### Method classification
 
 Methods in `Mt5TradingClient` fall into two categories:
@@ -44,8 +29,7 @@ show_bases: false
 Trading client that extends `Mt5DataClient` with direct order primitives
 (`place_market_order`, `_send_or_check_order`) and convenience wrappers
 (`calculate_minimum_order_margin`, `fetch_latest_rates_as_df`,
-`fetch_latest_ticks_as_df`). Higher-level operational orchestration belongs in
-`mt5cli`.
+`fetch_latest_ticks_as_df`).
 
 ### Mt5TradingError
 

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -1,11 +1,10 @@
-"""Trading operations module with advanced MetaTrader5 functionality."""
+"""Trading operations module for MetaTrader5 order primitives."""
 
 from __future__ import annotations
 
 import logging
 from datetime import timedelta
 from functools import cached_property
-from math import floor
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 from pydantic import ConfigDict
@@ -71,34 +70,15 @@ class Mt5TradingError(Mt5RuntimeError):
 
 
 class Mt5TradingClient(Mt5DataClient):
-    """MetaTrader5 trading client for direct order primitives and convenience helpers.
+    """MetaTrader5 trading client providing direct order primitives.
 
-    This class extends Mt5DataClient with thin wrappers around ``order_check`` /
-    ``order_send`` and a set of compatibility helpers retained from earlier versions
-    of the library.
+    This class extends ``Mt5DataClient`` with thin wrappers around
+    ``order_check`` / ``order_send`` and convenience helpers for common
+    single-call patterns.
 
-    **Responsibility boundary**
-
-    ``pdmt5`` is the core MetaTrader 5 Python API / pandas adapter.  Its scope
-    covers the MT5 connection lifecycle, low-level MT5 method wrappers, DataFrame
-    and dict conversion helpers, canonical MT5 constant parsing, and minimal direct
-    order primitives around ``order_check`` / ``order_send``.
-
-    Generic operational orchestration — such as margin-budget sizing, normalised
-    execution-result handling, broker constraint pre-checks, position-metric
-    computation, and downstream trading workflows — belongs in ``mt5cli``, which
-    is the canonical downstream operational SDK / CLI / batch / SQLite history
-    layer built on top of ``pdmt5``.
-
-    **Method classification**
-
-    * *Core MT5 primitive*: thin wrapper or constant mapping directly over the
-      MetaTrader5 Python API.  Always appropriate in ``pdmt5``.
-    * *Convenience wrapper*: slightly higher-level helper that remains closely
-      coupled to a single MT5 call and is appropriate in ``pdmt5``.
-    * *Compatibility helper*: higher-level operational helper retained for
-      backward compatibility.  New downstream applications should implement this
-      logic in ``mt5cli`` or their own layer instead.
+    Higher-level operational orchestration (margin-budget sizing, broker
+    constraint pre-checks, position-metric computation, batch workflows) belongs
+    in ``mt5cli``, the canonical downstream operational SDK built on ``pdmt5``.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -107,8 +87,9 @@ class Mt5TradingClient(Mt5DataClient):
     def mt5_successful_trade_retcodes(self) -> set[int]:
         """Set of successful trade return codes.
 
-        *Classification*: core MT5 primitive — maps ``TRADE_RETCODE_*`` constants
-        from the MetaTrader5 module into an integer set for retcode validation.
+        Maps ``TRADE_RETCODE_PLACED``, ``TRADE_RETCODE_DONE``, and
+        ``TRADE_RETCODE_DONE_PARTIAL`` from the MetaTrader5 module into an
+        integer set for retcode validation.
 
         Returns:
             Set of successful trade return codes.
@@ -121,105 +102,13 @@ class Mt5TradingClient(Mt5DataClient):
     def mt5_failed_trade_retcodes(self) -> set[int]:
         """Set of failed trade return codes.
 
-        *Classification*: core MT5 primitive — maps ``TRADE_RETCODE_*`` constants
-        from the MetaTrader5 module into an integer set for retcode validation.
+        Maps all ``TRADE_RETCODE_*`` failure constants from the MetaTrader5
+        module into an integer set for retcode validation.
 
         Returns:
             Set of failed trade return codes.
         """
         return {int(getattr(self.mt5, name)) for name in _FAILED_TRADE_RETCODE_NAMES}
-
-    def close_open_positions(
-        self,
-        symbols: str | list[str] | tuple[str, ...] | None = None,
-        order_filling_mode: Literal["IOC", "FOK", "RETURN"] = "IOC",
-        dry_run: bool = False,
-        **kwargs: Any,  # noqa: ANN401
-    ) -> dict[str, list[dict[str, Any]]]:
-        """Close all open positions for specified symbols.
-
-        *Classification*: compatibility helper — orchestrates position fetching and
-        closing across one or more symbols.  New downstream applications should
-        implement this workflow in ``mt5cli`` or their own layer rather than
-        relying on this method.
-
-        Args:
-            symbols: Optional symbol or list of symbols to filter positions.
-                If None, all symbols will be considered.
-            order_filling_mode: Order filling mode, either "IOC", "FOK", or "RETURN".
-            dry_run: If True, only check the order without sending it.
-            **kwargs: Additional keyword arguments for request parameters.
-
-        Returns:
-            Dictionary with symbols as keys and lists of dictionaries containing
-                operation results for each closed position as values.
-        """
-        if isinstance(symbols, str):
-            symbol_list = [symbols]
-        elif isinstance(symbols, (list, tuple)):
-            symbol_list = symbols
-        else:
-            symbol_list = self.symbols_get()
-        logger.info("Fetching and closing positions for symbols: %s", symbol_list)
-        return {
-            s: self._fetch_and_close_position(
-                symbol=s,
-                order_filling_mode=order_filling_mode,
-                dry_run=dry_run,
-                **kwargs,
-            )
-            for s in symbol_list
-        }
-
-    def _fetch_and_close_position(
-        self,
-        symbol: str | None = None,
-        order_filling_mode: Literal["IOC", "FOK", "RETURN"] = "IOC",
-        raise_on_error: bool = False,
-        dry_run: bool = False,
-        **kwargs: Any,  # noqa: ANN401
-    ) -> list[dict[str, Any]]:
-        """Close all open positions for a specific symbol.
-
-        Args:
-            symbol: Optional symbol filter.
-            order_filling_mode: Order filling mode, either "IOC", "FOK", or "RETURN".
-            raise_on_error: If True, raise an exception on error.
-            dry_run: If True, only check the order without sending it.
-            **kwargs: Additional keyword arguments for request parameters.
-
-        Returns:
-            List of dictionaries with operation results for each closed position.
-        """
-        positions_dict = self.positions_get_as_dicts(symbol=symbol)
-        if not positions_dict:
-            logger.warning("No open positions found for symbol: %s", symbol)
-            return []
-        logger.info("Closing open positions for symbol: %s", symbol)
-        return [
-            self._send_or_check_order(
-                request={
-                    "action": self.mt5.TRADE_ACTION_DEAL,
-                    "symbol": p["symbol"],
-                    "volume": p["volume"],
-                    "type": (
-                        self.mt5.ORDER_TYPE_SELL
-                        if p["type"] == self.mt5.POSITION_TYPE_BUY
-                        else self.mt5.ORDER_TYPE_BUY
-                    ),
-                    "type_filling": getattr(
-                        self.mt5,
-                        f"ORDER_FILLING_{order_filling_mode}",
-                    ),
-                    "type_time": self.mt5.ORDER_TIME_GTC,
-                    "position": p["ticket"],
-                    **kwargs,
-                },
-                raise_on_error=raise_on_error,
-                dry_run=dry_run,
-            )
-            for p in positions_dict
-        ]
 
     def _send_or_check_order(
         self,
@@ -229,8 +118,8 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> dict[str, Any]:
         """Send or check an order request.
 
-        *Classification*: core MT5 primitive — routes to ``order_check`` or
-        ``order_send`` and validates the returned retcode.
+        Routes to ``order_check`` (dry run) or ``order_send`` (live) and
+        validates the returned retcode.
 
         Args:
             request: Order request dictionary.
@@ -277,11 +166,10 @@ class Mt5TradingClient(Mt5DataClient):
         dry_run: bool = False,
         **kwargs: Any,  # noqa: ANN401
     ) -> dict[str, Any]:
-        """Send or check an order request to place a market order.
+        """Send or check a market order request.
 
-        *Classification*: convenience wrapper — builds a ``TRADE_ACTION_DEAL``
-        request and delegates to ``_send_or_check_order``.  This is a minimal
-        direct order primitive appropriate in ``pdmt5``.
+        Builds a ``TRADE_ACTION_DEAL`` request from the provided parameters and
+        delegates to ``_send_or_check_order``.
 
         Args:
             symbol: Symbol for the order.
@@ -314,106 +202,19 @@ class Mt5TradingClient(Mt5DataClient):
             dry_run=dry_run,
         )
 
-    def update_sltp_for_open_positions(
-        self,
-        symbol: str,
-        stop_loss: float | None = None,
-        take_profit: float | None = None,
-        tickets: list[int] | None = None,
-        raise_on_error: bool = False,
-        dry_run: bool = False,
-        **kwargs: Any,  # noqa: ANN401
-    ) -> list[dict[str, Any]]:
-        """Change Stop Loss and Take Profit for open positions.
-
-        *Classification*: compatibility helper — orchestrates position fetching,
-        filtering, and ``TRADE_ACTION_SLTP`` request dispatch.  New downstream
-        applications should implement this workflow in ``mt5cli`` or their own
-        layer rather than relying on this method.
-
-        Args:
-            symbol: Symbol for the position.
-            stop_loss: New Stop Loss price. If None, it will not be changed.
-            take_profit: New Take Profit price. If None, it will not be changed.
-            tickets: List of position tickets to filter positions. If None, all open
-                positions for the symbol will be considered.
-            raise_on_error: If True, raise an error on operation failure.
-            dry_run: If True, only check the order without sending it.
-            **kwargs: Additional keyword arguments for request parameters.
-
-        Returns:
-            List of dictionaries with operation results for each updated position.
-        """
-        positions_df = self.positions_get_as_df(symbol=symbol)
-        if positions_df.empty:
-            logger.warning("No open positions found for symbol: %s", symbol)
-            return []
-        if tickets:
-            filtered_positions_df = positions_df.pipe(
-                lambda d: d[d["ticket"].isin(tickets)]
-            )
-        else:
-            filtered_positions_df = positions_df
-        if filtered_positions_df.empty:
-            logger.warning(
-                "No open positions found for symbol: %s with specified tickets: %s",
-                symbol,
-                tickets,
-            )
-            return []
-        symbol_info = self.symbol_info_as_dict(symbol=symbol)
-        sl = round(stop_loss, symbol_info["digits"]) if stop_loss else None
-        tp = round(take_profit, symbol_info["digits"]) if take_profit else None
-        order_requests = [
-            {
-                "action": self.mt5.TRADE_ACTION_SLTP,
-                "symbol": p["symbol"],
-                "position": p["ticket"],
-                "sl": (sl or p["sl"]),
-                "tp": (tp or p["tp"]),
-                **kwargs,
-            }
-            for _, p in filtered_positions_df.iterrows()
-            if sl != p["sl"] or tp != p["tp"]
-        ]
-        if not order_requests:
-            logger.info(
-                "No positions to update for symbol: %s with SL: %s and TP: %s",
-                symbol,
-                sl,
-                tp,
-            )
-            return []
-        logger.info(
-            "Updating SL/TP for %d positions for %s: %s/%s",
-            len(order_requests),
-            symbol,
-            sl,
-            tp,
-        )
-        return [
-            self._send_or_check_order(
-                request=request,
-                raise_on_error=raise_on_error,
-                dry_run=dry_run,
-            )
-            for request in order_requests
-        ]
-
     def calculate_minimum_order_margin(
         self,
         symbol: str,
         order_side: Literal["BUY", "SELL"],
     ) -> dict[str, float]:
-        """Calculate the minimum order margins for a given symbol.
+        """Calculate the minimum order margin for a given symbol and side.
 
-        *Classification*: convenience wrapper — combines ``symbol_info`` and
-        ``order_calc_margin`` to return the margin required for the minimum
-        allowable volume.  This is a thin utility helper appropriate in ``pdmt5``.
+        Combines ``symbol_info`` and ``order_calc_margin`` to return the margin
+        required for the broker's minimum allowable volume.
 
         Args:
-            symbol: Symbol for which to calculate the minimum order margins.
-            order_side: Optional side of the order, either "BUY" or "SELL".
+            symbol: Symbol for which to calculate the minimum order margin.
+            order_side: Side of the order, either "BUY" or "SELL".
 
         Returns:
             Dictionary with minimum volume and margin for the specified order side.
@@ -447,72 +248,6 @@ class Mt5TradingClient(Mt5DataClient):
             )
         return result
 
-    def calculate_volume_by_margin(
-        self,
-        symbol: str,
-        margin: float,
-        order_side: Literal["BUY", "SELL"],
-    ) -> float:
-        """Calculate volume based on margin for a given symbol and order side.
-
-        *Classification*: compatibility helper — implements margin-budget sizing
-        logic retained for backward compatibility.  New downstream applications
-        should implement margin-budget sizing in ``mt5cli`` or their own layer
-        rather than relying on this method.
-
-        Args:
-            symbol: Symbol for which to calculate the volume.
-            margin: Margin amount to use for the calculation.
-            order_side: Side of the order, either "BUY" or "SELL".
-
-        Returns:
-            Calculated volume as a float.
-        """
-        min_order_margin_dict = self.calculate_minimum_order_margin(
-            symbol=symbol,
-            order_side=order_side,
-        )
-        if min_order_margin_dict["margin"]:
-            result = (
-                floor(margin / min_order_margin_dict["margin"])
-                * min_order_margin_dict["volume"]
-            )
-        else:
-            result = 0.0
-        logger.info(
-            "Calculated volume by margin to %s %s: %s",
-            order_side,
-            symbol,
-            result,
-        )
-        return result
-
-    def calculate_spread_ratio(
-        self,
-        symbol: str,
-    ) -> float:
-        """Calculate the spread ratio for a given symbol.
-
-        *Classification*: compatibility helper — computes a normalised bid-ask
-        spread ratio as a broker constraint pre-check.  New downstream
-        applications should implement this pre-check in ``mt5cli`` or their own
-        layer rather than relying on this method.
-
-        Args:
-            symbol: Symbol for which to calculate the spread ratio.
-
-        Returns:
-            Spread ratio as a float.
-        """
-        symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
-        result = (
-            (symbol_info_tick["ask"] - symbol_info_tick["bid"])
-            / (symbol_info_tick["ask"] + symbol_info_tick["bid"])
-            * 2
-        )
-        logger.info("Calculated spread ratio for %s: %s", symbol, result)
-        return result
-
     def fetch_latest_rates_as_df(
         self,
         symbol: str,
@@ -520,11 +255,11 @@ class Mt5TradingClient(Mt5DataClient):
         count: int = 1440,
         index_keys: str | None = "time",
     ) -> pd.DataFrame:
-        """Fetch rate (OHLC) data as a DataFrame.
+        """Fetch the most recent OHLC bars as a DataFrame.
 
-        *Classification*: convenience wrapper — calls ``copy_rates_from_pos_as_df``
-        from position 0 after resolving the ``granularity`` string via
-        ``parse_timeframe``.  Appropriate in ``pdmt5``.
+        Resolves the ``granularity`` string (e.g. ``"M1"``, ``"H1"``) via
+        ``parse_timeframe`` and calls ``copy_rates_from_pos_as_df`` from
+        position 0.
 
         Args:
             symbol: Symbol to fetch data for.
@@ -566,11 +301,10 @@ class Mt5TradingClient(Mt5DataClient):
         seconds: int = 300,
         index_keys: str | None = "time_msc",
     ) -> pd.DataFrame:
-        """Fetch tick data as a DataFrame.
+        """Fetch recent tick data as a DataFrame.
 
-        *Classification*: convenience wrapper — calls ``copy_ticks_range_as_df``
-        centred on the last tick time after deriving the date range from ``seconds``.
-        Appropriate in ``pdmt5``.
+        Derives a date range centred on the last tick time and calls
+        ``copy_ticks_range_as_df``.
 
         Args:
             symbol: Symbol to fetch tick data for.
@@ -592,185 +326,5 @@ class Mt5TradingClient(Mt5DataClient):
             "Fetched latest ticks for %s: %d rows",
             symbol,
             result.shape[0],
-        )
-        return result
-
-    def collect_entry_deals_as_df(
-        self,
-        symbol: str,
-        history_seconds: int = 3600,
-        index_keys: str | None = "ticket",
-    ) -> pd.DataFrame:
-        """Collect entry deals as a DataFrame.
-
-        *Classification*: compatibility helper — fetches deal history and filters
-        to BUY/SELL entry deals.  This is operational deal-history logic retained
-        for backward compatibility; new downstream applications should implement
-        deal filtering in ``mt5cli`` or their own layer rather than relying on
-        this method.
-
-        Args:
-            symbol: Symbol to collect entry deals for.
-            history_seconds: Time range in seconds to fetch deals around the last tick.
-            index_keys: Optional index keys for the DataFrame.
-
-        Returns:
-            pd.DataFrame: Entry deals with time index.
-        """
-        last_tick_time = self.symbol_info_tick_as_dict(symbol=symbol)["time"]
-        deals_df = self.history_deals_get_as_df(
-            date_from=(last_tick_time - timedelta(seconds=history_seconds)),
-            date_to=(last_tick_time + timedelta(seconds=history_seconds)),
-            symbol=symbol,
-            index_keys=index_keys,
-        )
-        if deals_df.empty:
-            result = deals_df
-        else:
-            result = deals_df.pipe(
-                lambda d: d[
-                    d["entry"]
-                    & d["type"].isin({self.mt5.DEAL_TYPE_BUY, self.mt5.DEAL_TYPE_SELL})
-                ]
-            )
-        logger.info(
-            "Collected entry deals for %s: %d rows",
-            symbol,
-            result.shape[0],
-        )
-        return result
-
-    def fetch_positions_with_metrics_as_df(
-        self,
-        symbol: str,
-    ) -> pd.DataFrame:
-        """Fetch open positions as a DataFrame with additional metrics.
-
-        *Classification*: compatibility helper — augments the raw positions
-        DataFrame with derived columns such as elapsed time, margin, and profit
-        ratios.  This is position-metric computation logic retained for backward
-        compatibility; new downstream applications should implement position
-        analytics in ``mt5cli`` or their own layer rather than relying on this
-        method.
-
-        Args:
-            symbol: Symbol to fetch positions for.
-
-        Returns:
-            pd.DataFrame: DataFrame containing open positions with additional metrics.
-        """
-        positions_df = self.positions_get_as_df(symbol=symbol)
-        if positions_df.empty:
-            result = positions_df
-        else:
-            symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
-            ask_margin = self.order_calc_margin(
-                action=parse_order_type("BUY"),
-                symbol=symbol,
-                volume=1,
-                price=symbol_info_tick["ask"],
-            )
-            bid_margin = self.order_calc_margin(
-                action=parse_order_type("SELL"),
-                symbol=symbol,
-                volume=1,
-                price=symbol_info_tick["bid"],
-            )
-            result = (
-                positions_df
-                .assign(
-                    elapsed_seconds=lambda d: (
-                        symbol_info_tick["time"] - d["time"]
-                    ).dt.total_seconds(),
-                    underlier_increase_ratio=lambda d: (
-                        d["price_current"] / d["price_open"] - 1
-                    ),
-                    buy=lambda d: d["type"] == self.mt5.POSITION_TYPE_BUY,
-                    sell=lambda d: d["type"] == self.mt5.POSITION_TYPE_SELL,
-                )
-                .assign(
-                    buy_i=lambda d: d["buy"].astype(int),
-                    sell_i=lambda d: d["sell"].astype(int),
-                )
-                .assign(
-                    sign=lambda d: d["buy_i"] - d["sell_i"],
-                    margin=lambda d: (
-                        (d["buy_i"] * ask_margin + d["sell_i"] * bid_margin)
-                        * d["volume"]
-                    ),
-                )
-                .assign(
-                    signed_volume=lambda d: d["volume"] * d["sign"],
-                    signed_margin=lambda d: d["margin"] * d["sign"],
-                    underlier_profit_ratio=lambda d: (
-                        d["underlier_increase_ratio"] * d["sign"]
-                    ),
-                )
-                .drop(columns=["buy_i", "sell_i", "sign", "underlier_increase_ratio"])
-            )
-        logger.info(
-            "Fetched positions with metrics for %s: %d rows",
-            symbol,
-            result.shape[0],
-        )
-        return result
-
-    def calculate_new_position_margin_ratio(
-        self,
-        symbol: str,
-        new_position_side: Literal["BUY", "SELL"] | None = None,
-        new_position_volume: float = 0,
-    ) -> float:
-        """Calculate the margin ratio for a new position.
-
-        *Classification*: compatibility helper — combines account equity, existing
-        position signed margins, and a prospective new-position margin to compute
-        a margin-utilisation ratio.  This is margin-budget sizing logic retained
-        for backward compatibility; new downstream applications should implement
-        margin-budget logic in ``mt5cli`` or their own layer rather than relying
-        on this method.
-
-        Args:
-            symbol: Symbol for which to calculate the margin ratio.
-            new_position_side: Side of the new position, either "BUY" or "SELL".
-            new_position_volume: Volume of the new position.
-
-        Returns:
-            float: Margin ratio for the new position as a fraction of account equity.
-        """
-        account_info = self.account_info_as_dict()
-        if not account_info["equity"]:
-            result = 0.0
-        else:
-            positions_df = self.fetch_positions_with_metrics_as_df(symbol=symbol)
-            current_signed_margin = (
-                positions_df["signed_margin"].sum() if positions_df.size else 0
-            )
-            symbol_info_tick = self.symbol_info_tick_as_dict(symbol=symbol)
-            if not (new_position_side and new_position_volume):
-                new_signed_margin = 0
-            elif new_position_side.upper() == "BUY":
-                new_signed_margin = self.order_calc_margin(
-                    action=parse_order_type("BUY"),
-                    symbol=symbol,
-                    volume=new_position_volume,
-                    price=symbol_info_tick["ask"],
-                )
-            elif new_position_side.upper() == "SELL":
-                new_signed_margin = -self.order_calc_margin(
-                    action=parse_order_type("SELL"),
-                    symbol=symbol,
-                    volume=new_position_volume,
-                    price=symbol_info_tick["bid"],
-                )
-            else:
-                new_signed_margin = 0
-            result = abs(
-                (new_signed_margin + current_signed_margin) / account_info["equity"]
-            )
-        logger.info(
-            "Calculated new position margin ratio for %s: %s",
-            symbol,
-            result,
         )
         return result

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -71,10 +71,34 @@ class Mt5TradingError(Mt5RuntimeError):
 
 
 class Mt5TradingClient(Mt5DataClient):
-    """MetaTrader5 trading client with advanced trading operations.
+    """MetaTrader5 trading client for direct order primitives and convenience helpers.
 
-    This class extends Mt5DataClient to provide specialized trading functionality
-    including position management, order analysis, and trading performance metrics.
+    This class extends Mt5DataClient with thin wrappers around ``order_check`` /
+    ``order_send`` and a set of compatibility helpers retained from earlier versions
+    of the library.
+
+    **Responsibility boundary**
+
+    ``pdmt5`` is the core MetaTrader 5 Python API / pandas adapter.  Its scope
+    covers the MT5 connection lifecycle, low-level MT5 method wrappers, DataFrame
+    and dict conversion helpers, canonical MT5 constant parsing, and minimal direct
+    order primitives around ``order_check`` / ``order_send``.
+
+    Generic operational orchestration — such as margin-budget sizing, normalised
+    execution-result handling, broker constraint pre-checks, position-metric
+    computation, and downstream trading workflows — belongs in ``mt5cli``, which
+    is the canonical downstream operational SDK / CLI / batch / SQLite history
+    layer built on top of ``pdmt5``.
+
+    **Method classification**
+
+    * *Core MT5 primitive*: thin wrapper or constant mapping directly over the
+      MetaTrader5 Python API.  Always appropriate in ``pdmt5``.
+    * *Convenience wrapper*: slightly higher-level helper that remains closely
+      coupled to a single MT5 call and is appropriate in ``pdmt5``.
+    * *Compatibility helper*: higher-level operational helper retained for
+      backward compatibility.  New downstream applications should implement this
+      logic in ``mt5cli`` or their own layer instead.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -82,6 +106,9 @@ class Mt5TradingClient(Mt5DataClient):
     @cached_property
     def mt5_successful_trade_retcodes(self) -> set[int]:
         """Set of successful trade return codes.
+
+        *Classification*: core MT5 primitive — maps ``TRADE_RETCODE_*`` constants
+        from the MetaTrader5 module into an integer set for retcode validation.
 
         Returns:
             Set of successful trade return codes.
@@ -93,6 +120,9 @@ class Mt5TradingClient(Mt5DataClient):
     @cached_property
     def mt5_failed_trade_retcodes(self) -> set[int]:
         """Set of failed trade return codes.
+
+        *Classification*: core MT5 primitive — maps ``TRADE_RETCODE_*`` constants
+        from the MetaTrader5 module into an integer set for retcode validation.
 
         Returns:
             Set of failed trade return codes.
@@ -107,6 +137,11 @@ class Mt5TradingClient(Mt5DataClient):
         **kwargs: Any,  # noqa: ANN401
     ) -> dict[str, list[dict[str, Any]]]:
         """Close all open positions for specified symbols.
+
+        *Classification*: compatibility helper — orchestrates position fetching and
+        closing across one or more symbols.  New downstream applications should
+        implement this workflow in ``mt5cli`` or their own layer rather than
+        relying on this method.
 
         Args:
             symbols: Optional symbol or list of symbols to filter positions.
@@ -194,6 +229,9 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> dict[str, Any]:
         """Send or check an order request.
 
+        *Classification*: core MT5 primitive — routes to ``order_check`` or
+        ``order_send`` and validates the returned retcode.
+
         Args:
             request: Order request dictionary.
             raise_on_error: If True, raise an error on operation failure.
@@ -241,6 +279,10 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> dict[str, Any]:
         """Send or check an order request to place a market order.
 
+        *Classification*: convenience wrapper — builds a ``TRADE_ACTION_DEAL``
+        request and delegates to ``_send_or_check_order``.  This is a minimal
+        direct order primitive appropriate in ``pdmt5``.
+
         Args:
             symbol: Symbol for the order.
             volume: Volume of the order.
@@ -283,6 +325,11 @@ class Mt5TradingClient(Mt5DataClient):
         **kwargs: Any,  # noqa: ANN401
     ) -> list[dict[str, Any]]:
         """Change Stop Loss and Take Profit for open positions.
+
+        *Classification*: compatibility helper — orchestrates position fetching,
+        filtering, and ``TRADE_ACTION_SLTP`` request dispatch.  New downstream
+        applications should implement this workflow in ``mt5cli`` or their own
+        layer rather than relying on this method.
 
         Args:
             symbol: Symbol for the position.
@@ -360,6 +407,10 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> dict[str, float]:
         """Calculate the minimum order margins for a given symbol.
 
+        *Classification*: convenience wrapper — combines ``symbol_info`` and
+        ``order_calc_margin`` to return the margin required for the minimum
+        allowable volume.  This is a thin utility helper appropriate in ``pdmt5``.
+
         Args:
             symbol: Symbol for which to calculate the minimum order margins.
             order_side: Optional side of the order, either "BUY" or "SELL".
@@ -404,6 +455,11 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> float:
         """Calculate volume based on margin for a given symbol and order side.
 
+        *Classification*: compatibility helper — implements margin-budget sizing
+        logic retained for backward compatibility.  New downstream applications
+        should implement margin-budget sizing in ``mt5cli`` or their own layer
+        rather than relying on this method.
+
         Args:
             symbol: Symbol for which to calculate the volume.
             margin: Margin amount to use for the calculation.
@@ -437,6 +493,11 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> float:
         """Calculate the spread ratio for a given symbol.
 
+        *Classification*: compatibility helper — computes a normalised bid-ask
+        spread ratio as a broker constraint pre-check.  New downstream
+        applications should implement this pre-check in ``mt5cli`` or their own
+        layer rather than relying on this method.
+
         Args:
             symbol: Symbol for which to calculate the spread ratio.
 
@@ -460,6 +521,10 @@ class Mt5TradingClient(Mt5DataClient):
         index_keys: str | None = "time",
     ) -> pd.DataFrame:
         """Fetch rate (OHLC) data as a DataFrame.
+
+        *Classification*: convenience wrapper — calls ``copy_rates_from_pos_as_df``
+        from position 0 after resolving the ``granularity`` string via
+        ``parse_timeframe``.  Appropriate in ``pdmt5``.
 
         Args:
             symbol: Symbol to fetch data for.
@@ -503,6 +568,10 @@ class Mt5TradingClient(Mt5DataClient):
     ) -> pd.DataFrame:
         """Fetch tick data as a DataFrame.
 
+        *Classification*: convenience wrapper — calls ``copy_ticks_range_as_df``
+        centred on the last tick time after deriving the date range from ``seconds``.
+        Appropriate in ``pdmt5``.
+
         Args:
             symbol: Symbol to fetch tick data for.
             seconds: Time range in seconds to fetch ticks around the last tick time.
@@ -533,6 +602,12 @@ class Mt5TradingClient(Mt5DataClient):
         index_keys: str | None = "ticket",
     ) -> pd.DataFrame:
         """Collect entry deals as a DataFrame.
+
+        *Classification*: compatibility helper — fetches deal history and filters
+        to BUY/SELL entry deals.  This is operational deal-history logic retained
+        for backward compatibility; new downstream applications should implement
+        deal filtering in ``mt5cli`` or their own layer rather than relying on
+        this method.
 
         Args:
             symbol: Symbol to collect entry deals for.
@@ -570,6 +645,13 @@ class Mt5TradingClient(Mt5DataClient):
         symbol: str,
     ) -> pd.DataFrame:
         """Fetch open positions as a DataFrame with additional metrics.
+
+        *Classification*: compatibility helper — augments the raw positions
+        DataFrame with derived columns such as elapsed time, margin, and profit
+        ratios.  This is position-metric computation logic retained for backward
+        compatibility; new downstream applications should implement position
+        analytics in ``mt5cli`` or their own layer rather than relying on this
+        method.
 
         Args:
             symbol: Symbol to fetch positions for.
@@ -640,6 +722,13 @@ class Mt5TradingClient(Mt5DataClient):
         new_position_volume: float = 0,
     ) -> float:
         """Calculate the margin ratio for a new position.
+
+        *Classification*: compatibility helper — combines account equity, existing
+        position signed margins, and a prospective new-position margin to compute
+        a margin-utilisation ratio.  This is margin-budget sizing logic retained
+        for backward compatibility; new downstream applications should implement
+        margin-budget logic in ``mt5cli`` or their own layer rather than relying
+        on this method.
 
         Args:
             symbol: Symbol for which to calculate the margin ratio.

--- a/pdmt5/trading.py
+++ b/pdmt5/trading.py
@@ -77,8 +77,8 @@ class Mt5TradingClient(Mt5DataClient):
     single-call patterns.
 
     Higher-level operational orchestration (margin-budget sizing, broker
-    constraint pre-checks, position-metric computation, batch workflows) belongs
-    in ``mt5cli``, the canonical downstream operational SDK built on ``pdmt5``.
+    constraint pre-checks, position-metric computation, batch workflows) is out
+    of scope for this package.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "0.3.1"
+version = "1.0.0"
 description = "Pandas-based data handler for MetaTrader 5"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
@@ -14,7 +14,7 @@ dependencies = [
   "pydantic >= 2.9.0",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "License :: OSI Approved :: MIT License",
   "Operating System :: Microsoft :: Windows",

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -2,10 +2,9 @@
 
 from collections.abc import Generator
 from types import ModuleType
-from typing import Any, Literal, NamedTuple, cast
+from typing import Any, Literal, cast
 
 import numpy as np
-import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
 
@@ -31,15 +30,13 @@ _MT5_METHODS = (
     "order_calc_margin",
     "copy_rates_from_pos",
     "copy_ticks_range",
-    "history_deals_get",
 )
 
 _MT5_CONSTANTS = {
+    "RES_S_OK": 1,
     "TRADE_ACTION_DEAL": 1,
     "ORDER_TYPE_BUY": 0,
     "ORDER_TYPE_SELL": 1,
-    "POSITION_TYPE_BUY": 0,
-    "POSITION_TYPE_SELL": 1,
     "ORDER_FILLING_IOC": 1,
     "ORDER_FILLING_FOK": 2,
     "ORDER_FILLING_RETURN": 3,
@@ -85,9 +82,6 @@ _MT5_CONSTANTS = {
     "TRADE_RETCODE_CLOSE_ONLY": 10044,
     "TRADE_RETCODE_FIFO_CLOSE": 10045,
     "TRADE_RETCODE_HEDGE_PROHIBITED": 10046,
-    "RES_S_OK": 1,
-    "DEAL_TYPE_BUY": 0,
-    "DEAL_TYPE_SELL": 1,
 }
 
 
@@ -123,82 +117,6 @@ def create_initialized_client(mock_mt5_import: ModuleType) -> Mt5TradingClient:
     return client
 
 
-class MockPositionInfo(NamedTuple):
-    """Mock position info structure."""
-
-    ticket: int
-    symbol: str
-    volume: float
-    type: int
-    time: int
-    identifier: int
-    reason: int
-    price_open: float
-    sl: float
-    tp: float
-    price_current: float
-    swap: float
-    profit: float
-    magic: int
-    comment: str
-    external_id: str
-
-
-class MockDealInfo(NamedTuple):
-    """Mock deal info structure."""
-
-    ticket: int
-    type: int
-    entry: bool
-    time: int
-
-
-@pytest.fixture
-def mock_position_buy() -> MockPositionInfo:
-    """Mock buy position."""
-    return MockPositionInfo(
-        ticket=12345,
-        symbol="EURUSD",
-        volume=0.1,
-        type=0,  # POSITION_TYPE_BUY
-        time=1234567890,
-        identifier=12345,
-        reason=0,
-        price_open=1.2000,
-        sl=0.0,
-        tp=0.0,
-        price_current=1.2050,
-        swap=0.0,
-        profit=5.0,
-        magic=0,
-        comment="test",
-        external_id="",
-    )
-
-
-@pytest.fixture
-def mock_position_sell() -> MockPositionInfo:
-    """Mock sell position."""
-    return MockPositionInfo(
-        ticket=12346,
-        symbol="GBPUSD",
-        volume=0.2,
-        type=1,  # POSITION_TYPE_SELL
-        time=1234567890,
-        identifier=12346,
-        reason=0,
-        price_open=1.3000,
-        sl=0.0,
-        tp=0.0,
-        price_current=1.2950,
-        swap=0.0,
-        profit=10.0,
-        magic=0,
-        comment="test",
-        external_id="",
-    )
-
-
 class TestMt5TradingError:
     """Tests for Mt5TradingError exception class."""
 
@@ -225,262 +143,12 @@ class TestMt5TradingClient:
     def test_client_initialization_default(self, mock_mt5_import: ModuleType) -> None:
         """Test client initialization with default parameters."""
         client = Mt5TradingClient(mt5=mock_mt5_import)
-        # Order filling mode is now a parameter, not an attribute
         assert isinstance(client, Mt5TradingClient)
 
     def test_client_initialization_custom(self, mock_mt5_import: ModuleType) -> None:
         """Test client initialization with custom parameters."""
-        # Order filling mode is now a parameter to methods, not a class attribute
-        client = Mt5TradingClient(
-            mt5=mock_mt5_import,
-        )
-        assert isinstance(client, Mt5TradingClient)
-
-    def test_client_initialization_invalid_filling_mode(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test client initialization with invalid filling mode."""
-        # Order filling mode is now a parameter to methods, not a class attribute
         client = Mt5TradingClient(mt5=mock_mt5_import)
-        # Test that the method validates the parameter
-        mock_mt5_import.initialize.return_value = True
-        client.initialize()
-        mock_mt5_import.positions_get.return_value = []
-        # Should not raise as validation happens at method level
-        result = client._fetch_and_close_position(  # type: ignore[reportPrivateUsage]
-            order_filling_mode="IOC"
-        )
-        assert result == []
-
-    def test_close_position_no_positions(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test close_position when no positions exist."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        result = client.close_open_positions("EURUSD")
-
-        assert result == {"EURUSD": []}
-        mock_mt5_import.positions_get.assert_called_once_with(symbol="EURUSD")
-
-    def test_close_position_with_positions(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_position with existing positions."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009,
-            "result": "success",
-        }
-
-        result = client.close_open_positions("EURUSD")
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 10009
-        mock_mt5_import.order_send.assert_called_once()
-
-    def test_close_position_with_positions_dry_run(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_position with existing positions in dry run mode."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_check.return_value.retcode = 0
-        mock_mt5_import.order_check.return_value._asdict.return_value = {
-            "retcode": 0,
-            "result": "check_success",
-        }
-
-        result = client.close_open_positions("EURUSD", dry_run=True)
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 0
-        mock_mt5_import.order_check.assert_called_once()
-        mock_mt5_import.order_send.assert_not_called()
-
-    def test_close_position_with_dry_run_override(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_position with dry_run parameter override."""
-        # Client initialized without dry_run
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_check.return_value.retcode = 0
-        mock_mt5_import.order_check.return_value._asdict.return_value = {
-            "retcode": 0,
-            "result": "check_success",
-        }
-
-        # Override with dry_run=True
-        result = client.close_open_positions("EURUSD", dry_run=True)
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 0
-        # Should use order_check instead of order_send
-        mock_mt5_import.order_check.assert_called_once()
-        mock_mt5_import.order_send.assert_not_called()
-
-    def test_close_position_with_real_mode_override(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_position with real mode override."""
-        # Client initialized without dry_run
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009,
-            "result": "send_success",
-        }
-
-        # Override with dry_run=False
-        result = client.close_open_positions("EURUSD", dry_run=False)
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 10009
-        # Should use order_send instead of order_check
-        mock_mt5_import.order_send.assert_called_once()
-        mock_mt5_import.order_check.assert_not_called()
-
-    def test_close_open_positions_all_symbols(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test close_open_positions for all symbols."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbols and positions
-        mock_mt5_import.symbols_get.return_value = ["EURUSD", "GBPUSD"]
-        mock_mt5_import.positions_get.return_value = []  # No positions
-
-        result = client.close_open_positions()
-
-        assert len(result) == 2
-        assert "EURUSD" in result
-        assert "GBPUSD" in result
-        assert result["EURUSD"] == []
-        assert result["GBPUSD"] == []
-
-    def test_close_open_positions_specific_symbols(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test close_open_positions for specific symbols."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        result = client.close_open_positions(["EURUSD"])
-
-        assert len(result) == 1
-        assert "EURUSD" in result
-        assert result["EURUSD"] == []
-
-    def test_close_open_positions_tuple_input(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test close_open_positions with tuple input."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        result = client.close_open_positions(("EURUSD", "GBPUSD"))
-
-        assert len(result) == 2
-        assert "EURUSD" in result
-        assert "GBPUSD" in result
-        assert result["EURUSD"] == []
-        assert result["GBPUSD"] == []
-
-    def test_close_open_positions_with_kwargs(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_open_positions with additional kwargs."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009,
-            "result": "success",
-        }
-
-        # Pass custom kwargs
-        result = client.close_open_positions(
-            "EURUSD", comment="custom_close", magic=12345
-        )
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 10009
-
-        # Check that kwargs were passed through
-        call_args = mock_mt5_import.order_send.call_args[0][0]
-        assert call_args["comment"] == "custom_close"
-        assert call_args["magic"] == 12345
-
-    def test_close_open_positions_with_kwargs_and_dry_run(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test close_open_positions with additional kwargs and dry_run override."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_check.return_value.retcode = 0
-        mock_mt5_import.order_check.return_value._asdict.return_value = {
-            "retcode": 0,
-            "result": "check_success",
-        }
-
-        # Pass custom kwargs with dry_run override
-        result = client.close_open_positions(
-            "EURUSD", dry_run=True, comment="custom_close", magic=12345
-        )
-
-        assert len(result["EURUSD"]) == 1
-        assert result["EURUSD"][0]["retcode"] == 0
-
-        # Check that kwargs were passed through to order_check
-        call_args = mock_mt5_import.order_check.call_args[0][0]
-        assert call_args["comment"] == "custom_close"
-        assert call_args["magic"] == 12345
-        mock_mt5_import.order_send.assert_not_called()
+        assert isinstance(client, Mt5TradingClient)
 
     def test_send_or_check_order_dry_run_success(
         self,
@@ -496,7 +164,6 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock successful order check
         mock_mt5_import.order_check.return_value.retcode = 0
         mock_mt5_import.order_check.return_value._asdict.return_value = {
             "retcode": 0,
@@ -526,7 +193,6 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock successful order send
         mock_mt5_import.order_send.return_value.retcode = 10009
         mock_mt5_import.order_send.return_value._asdict.return_value = {
             "retcode": 10009,
@@ -588,7 +254,6 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock failure response with error retcode
         mock_mt5_import.order_send.return_value.retcode = 10006
         mock_mt5_import.order_send.return_value._asdict.return_value = {
             "retcode": 10006,
@@ -615,7 +280,6 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock failure response with non-zero retcode for dry run
         mock_mt5_import.order_check.return_value.retcode = 10013
         mock_mt5_import.order_check.return_value._asdict.return_value = {
             "retcode": 10013,
@@ -636,7 +300,6 @@ class TestMt5TradingClient:
         mock_mt5_import: ModuleType,
     ) -> None:
         """Test _send_or_check_order with dry_run parameter override."""
-        # Client initialized without dry_run
         client = create_initialized_client(mock_mt5_import)
 
         request = {
@@ -646,14 +309,12 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock successful order check
         mock_mt5_import.order_check.return_value.retcode = 0
         mock_mt5_import.order_check.return_value._asdict.return_value = {
             "retcode": 0,
             "result": "check_success",
         }
 
-        # Override with dry_run=True
         result = client._send_or_check_order(  # type: ignore[reportPrivateUsage]
             request,
             dry_run=True,
@@ -661,7 +322,6 @@ class TestMt5TradingClient:
 
         assert result["retcode"] == 0
         assert result["result"] == "check_success"
-        # Should call order_check, not order_send
         mock_mt5_import.order_check.assert_called_once_with(request)
         mock_mt5_import.order_send.assert_not_called()
 
@@ -670,7 +330,6 @@ class TestMt5TradingClient:
         mock_mt5_import: ModuleType,
     ) -> None:
         """Test _send_or_check_order with real mode override."""
-        # Client initialized without dry_run
         client = create_initialized_client(mock_mt5_import)
 
         request = {
@@ -680,14 +339,12 @@ class TestMt5TradingClient:
             "type": 1,
         }
 
-        # Mock successful order send
         mock_mt5_import.order_send.return_value.retcode = 10009
         mock_mt5_import.order_send.return_value._asdict.return_value = {
             "retcode": 10009,
             "result": "send_success",
         }
 
-        # Override with dry_run=False
         result = client._send_or_check_order(  # type: ignore[reportPrivateUsage]
             request,
             dry_run=False,
@@ -695,7 +352,6 @@ class TestMt5TradingClient:
 
         assert result["retcode"] == 10009
         assert result["result"] == "send_success"
-        # Should call order_send, not order_check
         mock_mt5_import.order_send.assert_called_once_with(request)
         mock_mt5_import.order_check.assert_not_called()
 
@@ -706,13 +362,11 @@ class TestMt5TradingClient:
         """Test place_market_order method."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Mock MT5 constants
         mock_mt5_import.ORDER_TYPE_BUY = 0  # type: ignore[reportAttributeAccessIssue]
         mock_mt5_import.ORDER_FILLING_IOC = 1  # type: ignore[reportAttributeAccessIssue]
         mock_mt5_import.ORDER_TIME_GTC = 0  # type: ignore[reportAttributeAccessIssue]
         mock_mt5_import.TRADE_ACTION_DEAL = 1  # type: ignore[reportAttributeAccessIssue]
 
-        # Mock successful order send
         mock_mt5_import.order_send.return_value.retcode = 10009
         mock_mt5_import.order_send.return_value._asdict.return_value = {
             "retcode": 10009,
@@ -732,7 +386,6 @@ class TestMt5TradingClient:
         assert result["deal"] == 123456
         assert result["order"] == 789012
 
-        # Verify the request was built correctly
         expected_request = {
             "action": 1,  # TRADE_ACTION_DEAL
             "symbol": "EURUSD",
@@ -742,126 +395,6 @@ class TestMt5TradingClient:
             "type_time": 0,  # ORDER_TIME_GTC
         }
         mock_mt5_import.order_send.assert_called_once_with(expected_request)
-
-    def test_order_filling_mode_constants(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test that order filling mode constants are used correctly."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock positions
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009
-        }
-
-        # Call _fetch_and_close_position with FOK mode
-        client._fetch_and_close_position(  # type: ignore[reportPrivateUsage]
-            "EURUSD",
-            order_filling_mode="FOK",
-        )
-
-        # Verify that ORDER_FILLING_FOK was used
-        call_args = mock_mt5_import.order_send.call_args[0][0]
-        assert call_args["type_filling"] == mock_mt5_import.ORDER_FILLING_FOK
-
-    def test_position_type_handling(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-        mock_position_sell: MockPositionInfo,
-    ) -> None:
-        """Test that position types are handled correctly for closing."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Test buy position -> sell order
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009
-        }
-
-        client.close_open_positions("EURUSD")
-
-        # Buy position should result in sell order
-        call_args = mock_mt5_import.order_send.call_args[0][0]
-        assert call_args["type"] == mock_mt5_import.ORDER_TYPE_SELL
-
-        # Test sell position -> buy order
-        mock_mt5_import.positions_get.return_value = [mock_position_sell]
-
-        mock_mt5_import.order_send.reset_mock()
-
-        client.close_open_positions("GBPUSD")
-
-        # Sell position should result in buy order
-        call_args = mock_mt5_import.order_send.call_args[0][0]
-        assert call_args["type"] == mock_mt5_import.ORDER_TYPE_BUY
-
-    def test_fetch_and_close_position_with_dry_run(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-        mock_position_sell: MockPositionInfo,
-    ) -> None:
-        """Test _fetch_and_close_position with dry_run parameter."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Test with multiple positions and dry_run override
-        mock_mt5_import.positions_get.return_value = [
-            mock_position_buy,
-            mock_position_sell,
-        ]
-
-        mock_mt5_import.order_check.return_value.retcode = 0
-        mock_mt5_import.order_check.return_value._asdict.return_value = {
-            "retcode": 0,
-            "result": "check_success",
-        }
-
-        # Call internal method directly with dry_run=True
-        result = client._fetch_and_close_position(  # type: ignore[reportPrivateUsage]
-            symbol="EURUSD",
-            dry_run=True,
-        )
-
-        assert len(result) == 2
-        assert all(r["retcode"] == 0 for r in result)
-        assert mock_mt5_import.order_check.call_count == 2
-        mock_mt5_import.order_send.assert_not_called()
-
-    def test_fetch_and_close_position_inherits_instance_dry_run(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,
-    ) -> None:
-        """Test _fetch_and_close_position does not inherit dry_run from instance."""
-        # Client initialized without dry_run
-        client = create_initialized_client(mock_mt5_import)
-
-        mock_mt5_import.positions_get.return_value = [mock_position_buy]
-
-        mock_mt5_import.order_check.return_value.retcode = 0
-        mock_mt5_import.order_check.return_value._asdict.return_value = {
-            "retcode": 0,
-            "result": "check_success",
-        }
-
-        # Call with dry_run=True explicitly
-        result = client._fetch_and_close_position(  # type: ignore[reportPrivateUsage]
-            symbol="EURUSD",
-            dry_run=True,
-        )
-
-        assert len(result) == 1
-        assert result[0]["retcode"] == 0
-        mock_mt5_import.order_check.assert_called_once()
-        mock_mt5_import.order_send.assert_not_called()
 
     @pytest.mark.parametrize(
         ("order_side", "order_type_attr", "price_key", "expected_margin"),
@@ -881,18 +414,14 @@ class TestMt5TradingClient:
         """Test successful calculation of minimum order margin."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Mock symbol info
         mock_mt5_import.symbol_info.return_value._asdict.return_value = {
             "volume_min": 0.01,
             "name": "EURUSD",
         }
-
-        # Mock symbol tick info
         mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
             "ask": 1.1000,
             "bid": 1.0998,
         }
-
         mock_mt5_import.order_calc_margin.return_value = expected_margin
 
         result = client.calculate_minimum_order_margin("EURUSD", order_side)
@@ -906,42 +435,6 @@ class TestMt5TradingClient:
             tick_info[price_key],
         )
 
-    @pytest.mark.parametrize(
-        ("order_side", "budget", "order_calc_margin_return", "expected_volume"),
-        [
-            ("BUY", 1000.0, 100.5, 0.09),
-            ("SELL", 500.0, 99.8, 0.05),
-        ],
-    )
-    def test_calculate_volume_by_margin_success(
-        self,
-        mock_mt5_import: ModuleType,
-        order_side: Literal["BUY", "SELL"],
-        budget: float,
-        order_calc_margin_return: float,
-        expected_volume: float,
-    ) -> None:
-        """Test successful calculation of volume by margin."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "volume_min": 0.01,
-            "name": "EURUSD",
-        }
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "ask": 1.1000,
-            "bid": 1.0998,
-        }
-
-        mock_mt5_import.order_calc_margin.return_value = order_calc_margin_return
-
-        result = client.calculate_volume_by_margin("EURUSD", budget, order_side)
-
-        assert result == expected_volume
-
     def test_calculate_minimum_order_margin_no_margin(
         self,
         mock_mt5_import: ModuleType,
@@ -949,19 +442,14 @@ class TestMt5TradingClient:
         """Test calculation when order_calc_margin returns zero."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Mock symbol info
         mock_mt5_import.symbol_info.return_value._asdict.return_value = {
             "volume_min": 0.01,
             "name": "EURUSD",
         }
-
-        # Mock symbol tick info
         mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
             "ask": 1.1000,
             "bid": 1.0998,
         }
-
-        # Mock order_calc_margin to return 0.0 (no margin required)
         mock_mt5_import.order_calc_margin.return_value = 0.0
 
         result = client.calculate_minimum_order_margin("EURUSD", "BUY")
@@ -974,53 +462,6 @@ class TestMt5TradingClient:
             1.1000,
         )
 
-    def test_calculate_volume_by_margin_zero_margin(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test calculation when minimum order margin is zero."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "volume_min": 0.01,
-            "name": "EURUSD",
-        }
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "ask": 1.1000,
-            "bid": 1.0998,
-        }
-
-        # Mock order_calc_margin to return 0.0 (no margin required)
-        mock_mt5_import.order_calc_margin.return_value = 0.0
-
-        result = client.calculate_volume_by_margin("EURUSD", 1000.0, "BUY")
-
-        # Should return 0.0 when margin is zero
-        assert result == 0.0
-
-    def test_calculate_spread_ratio(
-        self,
-        mock_mt5_import: ModuleType,
-    ) -> None:
-        """Test calculation of spread ratio."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        result = client.calculate_spread_ratio("EURUSD")
-
-        # Expected calculation: (1.1002 - 1.1000) / (1.1002 + 1.1000) * 2
-        expected = (1.1002 - 1.1000) / (1.1002 + 1.1000) * 2
-        assert result == expected
-        mock_mt5_import.symbol_info_tick.assert_called_once_with("EURUSD")
-
     def test_fetch_latest_rates_as_df_success(
         self,
         mock_mt5_import: ModuleType,
@@ -1028,10 +469,8 @@ class TestMt5TradingClient:
         """Test successful fetching of rate data as DataFrame."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Mock TIMEFRAME constant
         mock_mt5_import.TIMEFRAME_M1 = 1  # type: ignore[reportAttributeAccessIssue]
 
-        # Create structured array that mimics MT5 rates structure
         rates_dtype = np.dtype([
             ("time", "i8"),
             ("open", "f8"),
@@ -1042,21 +481,17 @@ class TestMt5TradingClient:
             ("spread", "i4"),
             ("real_volume", "i8"),
         ])
-
         mock_rates_data = np.array(
-            [
-                (1234567890, 1.1000, 1.1010, 1.0990, 1.1005, 100, 2, 10000),
-            ],
+            [(1234567890, 1.1000, 1.1010, 1.0990, 1.1005, 100, 2, 10000)],
             dtype=rates_dtype,
         )
-
         mock_mt5_import.copy_rates_from_pos.return_value = mock_rates_data
 
         result = client.fetch_latest_rates_as_df("EURUSD", granularity="M1", count=10)
 
         assert result is not None
         mock_mt5_import.copy_rates_from_pos.assert_called_once_with(
-            "EURUSD",  # symbol
+            "EURUSD",
             1,  # timeframe
             0,  # start_pos
             10,  # count
@@ -1069,7 +504,6 @@ class TestMt5TradingClient:
         """Test fetching rate data with invalid granularity."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Ensure the attribute doesn't exist for invalid granularity
         if hasattr(mock_mt5_import, "TIMEFRAME_INVALID"):
             delattr(mock_mt5_import, "TIMEFRAME_INVALID")
 
@@ -1086,17 +520,13 @@ class TestMt5TradingClient:
         """Test fetching tick data as DataFrame."""
         client = create_initialized_client(mock_mt5_import)
 
-        # Mock symbol tick info with time
         mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
             "time": 1234567890,
             "ask": 1.1002,
             "bid": 1.1000,
         }
-
-        # Mock copy ticks flag
         mock_mt5_import.COPY_TICKS_ALL = 1  # type: ignore[reportAttributeAccessIssue]
 
-        # Create structured array that mimics MT5 ticks structure
         ticks_dtype = np.dtype([
             ("time", "i8"),
             ("bid", "f8"),
@@ -1107,684 +537,26 @@ class TestMt5TradingClient:
             ("flags", "i4"),
             ("volume_real", "f8"),
         ])
-
         mock_ticks_data = np.array(
-            [
-                (1234567890, 1.1000, 1.1002, 1.1001, 100, 1234567890000, 0, 100.0),
-            ],
+            [(1234567890, 1.1000, 1.1002, 1.1001, 100, 1234567890000, 0, 100.0)],
             dtype=ticks_dtype,
         )
-
         mock_mt5_import.copy_ticks_range.return_value = mock_ticks_data
 
         result = client.fetch_latest_ticks_as_df("EURUSD", seconds=60)
 
         assert result is not None
-        # Verify the method was called
         mock_mt5_import.symbol_info_tick.assert_called_once_with("EURUSD")
 
-        # Verify copy_ticks_range was called with correct arguments
         call_args = mock_mt5_import.copy_ticks_range.call_args[0]
-        assert call_args[0] == "EURUSD"  # symbol
-        assert call_args[3] == -1  # flags (COPY_TICKS_ALL)
+        assert call_args[0] == "EURUSD"
+        assert call_args[3] == -1  # COPY_TICKS_ALL
 
-        # Verify result has the expected structure
         assert len(result) == 1
-        # time_msc is likely the index, not a column
         assert "bid" in result.columns
         assert "ask" in result.columns
         assert "last" in result.columns
         assert "volume" in result.columns
-
-    def test_collect_entry_deals_as_df(self, mock_mt5_import: ModuleType) -> None:
-        """Test collecting entry deals as DataFrame."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": 1234567890,
-        }
-
-        # Create mock deal objects
-        mock_deals = [
-            # BUY, entry
-            MockDealInfo(ticket=1001, type=0, entry=True, time=1234567890),
-            # SELL, entry
-            MockDealInfo(ticket=1002, type=1, entry=True, time=1234567891),
-            # other type, entry
-            MockDealInfo(ticket=1003, type=2, entry=True, time=1234567892),
-            # BUY, not entry
-            MockDealInfo(ticket=1004, type=0, entry=False, time=1234567893),
-            # SELL, entry
-            MockDealInfo(ticket=1005, type=1, entry=True, time=1234567894),
-        ]
-
-        # Mock history_deals_get to return the mock deals
-        mock_mt5_import.history_deals_get.return_value = mock_deals
-
-        result = client.collect_entry_deals_as_df("EURUSD", history_seconds=3600)
-
-        # Verify symbol_info_tick was called
-        mock_mt5_import.symbol_info_tick.assert_called_once_with("EURUSD")
-
-        # Verify history_deals_get was called with correct parameters
-        mock_mt5_import.history_deals_get.assert_called_once()
-        call_args = mock_mt5_import.history_deals_get.call_args
-        # Check positional args (date_from, date_to)
-        assert len(call_args[0]) == 2
-        date_from, date_to = call_args[0]
-        # Compare timestamps to avoid timezone issues
-        if isinstance(date_from, pd.Timestamp):
-            date_from_ts = date_from.timestamp()
-        else:
-            date_from_ts = date_from.timestamp()
-        if isinstance(date_to, pd.Timestamp):
-            date_to_ts = date_to.timestamp()
-        else:
-            date_to_ts = date_to.timestamp()
-
-        expected_from_ts = 1234567890 - 3600
-        expected_to_ts = 1234567890 + 3600
-        assert abs(date_from_ts - expected_from_ts) < 1  # Allow 1 second tolerance
-        assert abs(date_to_ts - expected_to_ts) < 1  # Allow 1 second tolerance
-        # Check group parameter
-        assert call_args[1]["group"] == "*EURUSD*"
-
-        # Verify filtered results - should only have entry deals with BUY/SELL types
-        assert len(result) == 3  # tickets 1001, 1002, 1005
-        assert 1001 in result.index  # entry=True, type=BUY
-        assert 1002 in result.index  # entry=True, type=SELL
-        assert 1003 not in result.index  # entry=True but type=2 (not BUY/SELL)
-        assert 1004 not in result.index  # entry=False
-        assert 1005 in result.index  # entry=True, type=SELL
-
-    def test_collect_entry_deals_as_df_custom_parameters(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test collecting entry deals with custom parameters."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": 1234567890,
-        }
-
-        # Mock empty deals
-        mock_mt5_import.history_deals_get.return_value = []
-
-        result = client.collect_entry_deals_as_df(
-            "GBPUSD", history_seconds=7200, index_keys="time"
-        )
-
-        # Verify parameters were passed through
-        mock_mt5_import.history_deals_get.assert_called_once()
-        call_args = mock_mt5_import.history_deals_get.call_args
-        # Check positional args
-        date_from, date_to = call_args[0]
-
-        # Compare timestamps to avoid timezone issues
-        if isinstance(date_from, pd.Timestamp):
-            date_from_ts = date_from.timestamp()
-        else:
-            date_from_ts = date_from.timestamp()
-        if isinstance(date_to, pd.Timestamp):
-            date_to_ts = date_to.timestamp()
-        else:
-            date_to_ts = date_to.timestamp()
-
-        expected_from_ts = 1234567890 - 7200
-        expected_to_ts = 1234567890 + 7200
-        assert abs(date_from_ts - expected_from_ts) < 1  # Allow 1 second tolerance
-        assert abs(date_to_ts - expected_to_ts) < 1  # Allow 1 second tolerance
-        # Check group parameter
-        assert call_args[1]["group"] == "*GBPUSD*"
-
-        # Result should be empty DataFrame
-        assert len(result) == 0
-
-    def test_collect_entry_deals_as_df_no_index(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test collecting entry deals without index."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": 1234567890,
-        }
-
-        # Create mock deal objects
-        mock_deals = [
-            # BUY, entry
-            MockDealInfo(ticket=1001, type=0, entry=True, time=1234567890),
-            # SELL, entry
-            MockDealInfo(ticket=1002, type=1, entry=True, time=1234567891),
-        ]
-
-        # Mock history_deals_get to return the mock deals
-        mock_mt5_import.history_deals_get.return_value = mock_deals
-
-        result = client.collect_entry_deals_as_df(
-            "USDJPY", history_seconds=1800, index_keys=None
-        )
-
-        # Verify results
-        assert len(result) == 2
-        # When index_keys is None, result should not have ticket as index
-        assert result.index.name is None
-        # Check that both deals are in the result
-        assert 1001 in result["ticket"].to_numpy()
-        assert 1002 in result["ticket"].to_numpy()
-
-    def test_fetch_positions_with_metrics_as_df_empty(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test fetching positions with metrics when no positions exist."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        result = client.fetch_positions_with_metrics_as_df("EURUSD")
-
-        # Should return empty DataFrame
-        assert result.empty
-        assert isinstance(result, pd.DataFrame)
-
-    def test_fetch_positions_with_metrics_as_df_with_positions(
-        self,
-        mock_mt5_import: ModuleType,
-        mock_position_buy: MockPositionInfo,  # noqa: ARG002
-        mocker: MockerFixture,
-    ) -> None:
-        """Test fetching positions with metrics when positions exist."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Create a mock position that returns the right data when converted
-        mock_position = mocker.MagicMock()
-        mock_position._asdict.return_value = {
-            "ticket": 12345,
-            "symbol": "EURUSD",
-            "volume": 0.1,
-            "type": 0,  # POSITION_TYPE_BUY
-            "time": 1234567890,  # This will be converted by decorator
-            "price_open": 1.2,
-            "price_current": 1.205,
-            "profit": 5.0,
-            "sl": 0.0,
-            "tp": 0.0,
-            "identifier": 12345,
-            "reason": 0,
-            "swap": 0.0,
-            "magic": 0,
-            "comment": "test",
-            "external_id": "",
-        }
-        mock_mt5_import.positions_get.return_value = [mock_position]
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp(
-                "2009-02-14 00:31:30"
-            ),  # tz-naive to match decorated positions
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        # Mock order calc margin
-        mock_mt5_import.order_calc_margin.return_value = 1000.0
-
-        result = client.fetch_positions_with_metrics_as_df("EURUSD")
-
-        # Verify DataFrame is not empty and has expected columns
-        assert not result.empty
-        assert isinstance(result, pd.DataFrame)
-        assert "elapsed_seconds" in result.columns
-        assert "underlier_profit_ratio" in result.columns
-        assert "buy" in result.columns
-        assert "sell" in result.columns
-        assert "margin" in result.columns
-        assert "signed_volume" in result.columns
-        assert "signed_margin" in result.columns
-
-        # Verify calculations
-        row = result.iloc[0]
-        assert row["buy"]  # mock_position_buy has type=0 (BUY)
-        assert not row["sell"]
-        assert row["margin"] == 100.0  # 0.1 volume * 1000 margin
-        assert row["signed_volume"] == 0.1  # buy position has positive volume
-        assert row["signed_margin"] == 100.0  # buy position has positive margin
-
-        # Verify order_calc_margin was called twice (ask and bid)
-        assert mock_mt5_import.order_calc_margin.call_count == 2
-
-    def test_calculate_new_position_margin_ratio_no_equity(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test calculating margin ratio when account has no equity."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info with zero equity
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 0.0,
-        }
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD", new_position_side="BUY", new_position_volume=0.1
-        )
-
-        assert result == 0.0
-
-    def test_calculate_new_position_margin_ratio_buy_position(
-        self, mock_mt5_import: ModuleType, mocker: MockerFixture
-    ) -> None:
-        """Test calculating margin ratio for a new buy position."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 10000.0,
-        }
-
-        # Mock existing positions
-        mock_position = mocker.MagicMock()
-        mock_position._asdict.return_value = {
-            "ticket": 12345,
-            "symbol": "EURUSD",
-            "volume": 0.1,
-            "type": 0,  # POSITION_TYPE_BUY
-            "time": 1234567890,
-            "price_open": 1.2,
-            "price_current": 1.205,
-            "profit": 5.0,
-            "sl": 0.0,
-            "tp": 0.0,
-            "identifier": 12345,
-            "reason": 0,
-            "swap": 0.0,
-            "magic": 0,
-            "comment": "test",
-            "external_id": "",
-        }
-        mock_mt5_import.positions_get.return_value = [mock_position]
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp("2009-02-14 00:31:30"),
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        # Mock order calc margin
-        mock_mt5_import.order_calc_margin.return_value = 1000.0
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD", new_position_side="BUY", new_position_volume=0.1
-        )
-
-        # Should return (new_margin + current_margin) / equity
-        # current_margin = 100.0 (from position), new_margin = 1000.0
-        expected_ratio = abs((1000.0 + 100.0) / 10000.0)
-        assert result == expected_ratio
-
-    def test_calculate_new_position_margin_ratio_sell_position(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test calculating margin ratio for a new sell position."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 10000.0,
-        }
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp("2009-02-14 00:31:30"),
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        # Mock order calc margin
-        mock_mt5_import.order_calc_margin.return_value = 1000.0
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD", new_position_side="SELL", new_position_volume=0.1
-        )
-
-        # Should return abs(-new_margin / equity) for sell
-        expected_ratio = abs(-1000.0 / 10000.0)
-        assert result == expected_ratio
-
-    def test_calculate_new_position_margin_ratio_zero_volume(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test calculating margin ratio with zero volume."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 10000.0,
-        }
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp("2009-02-14 00:31:30"),
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD", new_position_side="BUY", new_position_volume=0
-        )
-
-        # Should return 0 since new_position_volume is 0
-        assert result == 0.0
-
-    def test_calculate_new_position_margin_ratio_invalid_side(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test calculating margin ratio with invalid side."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 10000.0,
-        }
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp("2009-02-14 00:31:30"),
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD", new_position_side=None, new_position_volume=0.1
-        )
-
-        # Should return 0 since side is invalid
-        assert result == 0.0
-
-    def test_calculate_new_position_margin_ratio_invalid_side_string(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test calculating margin ratio with invalid side string."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock account info
-        mock_mt5_import.account_info.return_value._asdict.return_value = {
-            "equity": 10000.0,
-        }
-
-        # Mock empty positions
-        mock_mt5_import.positions_get.return_value = []
-
-        # Mock symbol tick info
-        mock_mt5_import.symbol_info_tick.return_value._asdict.return_value = {
-            "time": pd.Timestamp("2009-02-14 00:31:30"),
-            "ask": 1.1002,
-            "bid": 1.1000,
-        }
-
-        result = client.calculate_new_position_margin_ratio(
-            symbol="EURUSD",
-            new_position_side="INVALID",  # type: ignore[arg-type]
-            new_position_volume=0.1,
-        )
-
-        # Should return 0 since side is invalid string
-        assert result == 0.0
-
-    def test_update_sltp_for_open_positions(self, mock_mt5_import: ModuleType) -> None:
-        """Test update_sltp_for_open_positions method."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock MT5 constants
-        mock_mt5_import.TRADE_ACTION_SLTP = 6  # type: ignore[reportAttributeAccessIssue]
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "digits": 5,
-        }
-
-        # Mock positions for the symbol
-        mock_position = MockPositionInfo(
-            ticket=123456,
-            time=123456789,
-            type=0,  # buy
-            magic=0,
-            identifier=123456,
-            reason=0,
-            volume=0.1,
-            price_open=1.1000,
-            sl=1.0900,
-            tp=1.1100,
-            price_current=1.1050,
-            swap=0.0,
-            profit=50.0,
-            symbol="EURUSD",
-            comment="test",
-            external_id="",
-        )
-        mock_mt5_import.positions_get.return_value = [mock_position]
-
-        # Mock successful order send
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009,
-            "deal": 0,
-            "order": 789012,
-        }
-
-        result = client.update_sltp_for_open_positions(
-            symbol="EURUSD",
-            tickets=[123456],
-            stop_loss=1.0950,
-            take_profit=1.1050,
-        )
-
-        # Now returns a list of dictionaries
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0]["retcode"] == 10009
-        assert result[0]["order"] == 789012
-
-    def test_update_sltp_for_open_positions_no_positions(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test update_sltp_for_open_positions when no positions exist for symbol."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock empty positions result
-        mock_mt5_import.positions_get.return_value = []
-
-        result = client.update_sltp_for_open_positions(
-            symbol="EURUSD",
-            tickets=[123456],
-            stop_loss=1.0950,
-            take_profit=1.1050,
-        )
-
-        # Should return empty list and log warning
-        assert result == []
-        # Verify positions_get was called with correct symbol
-        mock_mt5_import.positions_get.assert_called_with(symbol="EURUSD")
-
-    def test_update_sltp_for_open_positions_no_matching_tickets(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test update_sltp_for_open_positions when positions exist but no tickets match."""  # noqa: E501
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock MT5 constants
-        mock_mt5_import.TRADE_ACTION_SLTP = 6  # type: ignore[reportAttributeAccessIssue]
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "digits": 5,
-        }
-
-        # Mock positions with different tickets
-        mock_position = MockPositionInfo(
-            ticket=999999,  # Different ticket
-            time=123456789,
-            type=0,  # buy
-            magic=0,
-            identifier=999999,
-            reason=0,
-            volume=0.1,
-            price_open=1.1000,
-            sl=1.0900,
-            tp=1.1100,
-            price_current=1.1050,
-            swap=0.0,
-            profit=50.0,
-            symbol="EURUSD",
-            comment="test",
-            external_id="",
-        )
-        mock_mt5_import.positions_get.return_value = [mock_position]
-
-        result = client.update_sltp_for_open_positions(
-            symbol="EURUSD",
-            tickets=[123456],  # This ticket doesn't exist
-            stop_loss=1.0950,
-            take_profit=1.1050,
-        )
-
-        # Should return empty list and log warning
-        assert result == []
-
-    def test_update_sltp_for_open_positions_same_sltp_values(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test update_sltp_for_open_positions when SL/TP values are already the same."""  # noqa: E501
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock MT5 constants
-        mock_mt5_import.TRADE_ACTION_SLTP = 6  # type: ignore[reportAttributeAccessIssue]
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "digits": 5,
-        }
-
-        # Mock positions with same SL/TP as requested
-        mock_position = MockPositionInfo(
-            ticket=123456,
-            time=123456789,
-            type=0,  # buy
-            magic=0,
-            identifier=123456,
-            reason=0,
-            volume=0.1,
-            price_open=1.1000,
-            sl=1.0950,  # Same as requested stop_loss
-            tp=1.1050,  # Same as requested take_profit
-            price_current=1.1050,
-            swap=0.0,
-            profit=50.0,
-            symbol="EURUSD",
-            comment="test",
-            external_id="",
-        )
-        mock_mt5_import.positions_get.return_value = [mock_position]
-
-        result = client.update_sltp_for_open_positions(
-            symbol="EURUSD",
-            tickets=[123456],
-            stop_loss=1.0950,  # Same as position's sl
-            take_profit=1.1050,  # Same as position's tp
-        )
-
-        # Should return empty list since no update is needed
-        assert result == []
-        # Verify order_send was NOT called
-        mock_mt5_import.order_send.assert_not_called()
-
-    def test_update_sltp_for_open_positions_no_tickets(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test update_sltp_for_open_positions without specifying tickets."""
-        client = create_initialized_client(mock_mt5_import)
-
-        # Mock MT5 constants
-        mock_mt5_import.TRADE_ACTION_SLTP = 6  # type: ignore[reportAttributeAccessIssue]
-
-        # Mock symbol info
-        mock_mt5_import.symbol_info.return_value._asdict.return_value = {
-            "digits": 5,
-        }
-
-        # Mock positions for the symbol
-        mock_position1 = MockPositionInfo(
-            ticket=123456,
-            time=123456789,
-            type=0,  # buy
-            magic=0,
-            identifier=123456,
-            reason=0,
-            volume=0.1,
-            price_open=1.1000,
-            sl=1.0900,
-            tp=1.1100,
-            price_current=1.1050,
-            swap=0.0,
-            profit=50.0,
-            symbol="EURUSD",
-            comment="test",
-            external_id="",
-        )
-        mock_position2 = MockPositionInfo(
-            ticket=654321,
-            time=123456789,
-            type=1,  # sell
-            magic=0,
-            identifier=654321,
-            reason=0,
-            volume=0.2,
-            price_open=1.1050,
-            sl=1.1150,
-            tp=1.0950,
-            price_current=1.1050,
-            swap=0.0,
-            profit=-20.0,
-            symbol="EURUSD",
-            comment="test2",
-            external_id="",
-        )
-        mock_mt5_import.positions_get.return_value = [mock_position1, mock_position2]
-
-        # Mock successful order send
-        mock_mt5_import.order_send.return_value.retcode = 10009
-        mock_mt5_import.order_send.return_value._asdict.return_value = {
-            "retcode": 10009,
-            "deal": 0,
-            "order": 789012,
-        }
-
-        # Call without tickets to update all positions
-        result = client.update_sltp_for_open_positions(
-            symbol="EURUSD",
-            tickets=None,  # No tickets specified
-            stop_loss=1.0950,
-            take_profit=1.1050,
-        )
-
-        # Should return results for both positions
-        assert isinstance(result, list)
-        assert len(result) == 2
-        assert all(r["retcode"] == 10009 for r in result)
 
     def test_mt5_successful_trade_retcodes_property(
         self, mock_mt5_import: ModuleType
@@ -1792,17 +564,13 @@ class TestMt5TradingClient:
         """Test mt5_successful_trade_retcodes property returns correct set of codes."""
         client = Mt5TradingClient(mt5=mock_mt5_import)
 
-        # Get the property value
         retcodes = client.mt5_successful_trade_retcodes
 
-        # Verify it's a set
         assert isinstance(retcodes, set)
-
-        # Verify the expected codes are present
         assert retcodes == {
-            mock_mt5_import.TRADE_RETCODE_PLACED,  # 10008
-            mock_mt5_import.TRADE_RETCODE_DONE,  # 10009
-            mock_mt5_import.TRADE_RETCODE_DONE_PARTIAL,  # 10010
+            mock_mt5_import.TRADE_RETCODE_PLACED,
+            mock_mt5_import.TRADE_RETCODE_DONE,
+            mock_mt5_import.TRADE_RETCODE_DONE_PARTIAL,
         }
 
     def test_mt5_failed_trade_retcodes_property(
@@ -1811,53 +579,47 @@ class TestMt5TradingClient:
         """Test mt5_failed_trade_retcodes property returns correct set of codes."""
         client = Mt5TradingClient(mt5=mock_mt5_import)
 
-        # Get the property value
         retcodes = client.mt5_failed_trade_retcodes
 
-        # Verify it's a set
         assert isinstance(retcodes, set)
-
-        # Verify it contains the expected codes
         expected_codes = {
-            mock_mt5_import.TRADE_RETCODE_REQUOTE,  # 10004
-            mock_mt5_import.TRADE_RETCODE_REJECT,  # 10006
-            mock_mt5_import.TRADE_RETCODE_CANCEL,  # 10007
-            mock_mt5_import.TRADE_RETCODE_ERROR,  # 10011
-            mock_mt5_import.TRADE_RETCODE_TIMEOUT,  # 10012
-            mock_mt5_import.TRADE_RETCODE_INVALID,  # 10013
-            mock_mt5_import.TRADE_RETCODE_INVALID_VOLUME,  # 10014
-            mock_mt5_import.TRADE_RETCODE_INVALID_PRICE,  # 10015
-            mock_mt5_import.TRADE_RETCODE_INVALID_STOPS,  # 10016
-            mock_mt5_import.TRADE_RETCODE_TRADE_DISABLED,  # 10017
-            mock_mt5_import.TRADE_RETCODE_MARKET_CLOSED,  # 10018
-            mock_mt5_import.TRADE_RETCODE_NO_MONEY,  # 10019
-            mock_mt5_import.TRADE_RETCODE_PRICE_CHANGED,  # 10020
-            mock_mt5_import.TRADE_RETCODE_PRICE_OFF,  # 10021
-            mock_mt5_import.TRADE_RETCODE_INVALID_EXPIRATION,  # 10022
-            mock_mt5_import.TRADE_RETCODE_ORDER_CHANGED,  # 10023
-            mock_mt5_import.TRADE_RETCODE_TOO_MANY_REQUESTS,  # 10024
-            mock_mt5_import.TRADE_RETCODE_NO_CHANGES,  # 10025
-            mock_mt5_import.TRADE_RETCODE_SERVER_DISABLES_AT,  # 10026
-            mock_mt5_import.TRADE_RETCODE_CLIENT_DISABLES_AT,  # 10027
-            mock_mt5_import.TRADE_RETCODE_LOCKED,  # 10028
-            mock_mt5_import.TRADE_RETCODE_FROZEN,  # 10029
-            mock_mt5_import.TRADE_RETCODE_INVALID_FILL,  # 10030
-            mock_mt5_import.TRADE_RETCODE_CONNECTION,  # 10031
-            mock_mt5_import.TRADE_RETCODE_ONLY_REAL,  # 10032
-            mock_mt5_import.TRADE_RETCODE_LIMIT_ORDERS,  # 10033
-            mock_mt5_import.TRADE_RETCODE_LIMIT_VOLUME,  # 10034
-            mock_mt5_import.TRADE_RETCODE_INVALID_ORDER,  # 10035
-            mock_mt5_import.TRADE_RETCODE_POSITION_CLOSED,  # 10036
-            mock_mt5_import.TRADE_RETCODE_INVALID_CLOSE_VOLUME,  # 10038
-            mock_mt5_import.TRADE_RETCODE_CLOSE_ORDER_EXIST,  # 10039
-            mock_mt5_import.TRADE_RETCODE_LIMIT_POSITIONS,  # 10040
-            mock_mt5_import.TRADE_RETCODE_REJECT_CANCEL,  # 10041
-            mock_mt5_import.TRADE_RETCODE_LONG_ONLY,  # 10042
-            mock_mt5_import.TRADE_RETCODE_SHORT_ONLY,  # 10043
-            mock_mt5_import.TRADE_RETCODE_CLOSE_ONLY,  # 10044
-            mock_mt5_import.TRADE_RETCODE_FIFO_CLOSE,  # 10045
-            mock_mt5_import.TRADE_RETCODE_HEDGE_PROHIBITED,  # 10046
+            mock_mt5_import.TRADE_RETCODE_REQUOTE,
+            mock_mt5_import.TRADE_RETCODE_REJECT,
+            mock_mt5_import.TRADE_RETCODE_CANCEL,
+            mock_mt5_import.TRADE_RETCODE_ERROR,
+            mock_mt5_import.TRADE_RETCODE_TIMEOUT,
+            mock_mt5_import.TRADE_RETCODE_INVALID,
+            mock_mt5_import.TRADE_RETCODE_INVALID_VOLUME,
+            mock_mt5_import.TRADE_RETCODE_INVALID_PRICE,
+            mock_mt5_import.TRADE_RETCODE_INVALID_STOPS,
+            mock_mt5_import.TRADE_RETCODE_TRADE_DISABLED,
+            mock_mt5_import.TRADE_RETCODE_MARKET_CLOSED,
+            mock_mt5_import.TRADE_RETCODE_NO_MONEY,
+            mock_mt5_import.TRADE_RETCODE_PRICE_CHANGED,
+            mock_mt5_import.TRADE_RETCODE_PRICE_OFF,
+            mock_mt5_import.TRADE_RETCODE_INVALID_EXPIRATION,
+            mock_mt5_import.TRADE_RETCODE_ORDER_CHANGED,
+            mock_mt5_import.TRADE_RETCODE_TOO_MANY_REQUESTS,
+            mock_mt5_import.TRADE_RETCODE_NO_CHANGES,
+            mock_mt5_import.TRADE_RETCODE_SERVER_DISABLES_AT,
+            mock_mt5_import.TRADE_RETCODE_CLIENT_DISABLES_AT,
+            mock_mt5_import.TRADE_RETCODE_LOCKED,
+            mock_mt5_import.TRADE_RETCODE_FROZEN,
+            mock_mt5_import.TRADE_RETCODE_INVALID_FILL,
+            mock_mt5_import.TRADE_RETCODE_CONNECTION,
+            mock_mt5_import.TRADE_RETCODE_ONLY_REAL,
+            mock_mt5_import.TRADE_RETCODE_LIMIT_ORDERS,
+            mock_mt5_import.TRADE_RETCODE_LIMIT_VOLUME,
+            mock_mt5_import.TRADE_RETCODE_INVALID_ORDER,
+            mock_mt5_import.TRADE_RETCODE_POSITION_CLOSED,
+            mock_mt5_import.TRADE_RETCODE_INVALID_CLOSE_VOLUME,
+            mock_mt5_import.TRADE_RETCODE_CLOSE_ORDER_EXIST,
+            mock_mt5_import.TRADE_RETCODE_LIMIT_POSITIONS,
+            mock_mt5_import.TRADE_RETCODE_REJECT_CANCEL,
+            mock_mt5_import.TRADE_RETCODE_LONG_ONLY,
+            mock_mt5_import.TRADE_RETCODE_SHORT_ONLY,
+            mock_mt5_import.TRADE_RETCODE_CLOSE_ONLY,
+            mock_mt5_import.TRADE_RETCODE_FIFO_CLOSE,
+            mock_mt5_import.TRADE_RETCODE_HEDGE_PROHIBITED,
         }
-
-        # Verify all expected codes are present
         assert retcodes == expected_codes

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.3.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
Remove all compatibility helpers from `Mt5TradingClient` and strip
ecosystem boundary descriptions from docs and docstrings.

## Changes

- **`pdmt5/trading.py`**: Drop seven higher-level operational methods
  (`close_open_positions`, `update_sltp_for_open_positions`,
  `calculate_volume_by_margin`, `calculate_spread_ratio`,
  `collect_entry_deals_as_df`, `fetch_positions_with_metrics_as_df`,
  `calculate_new_position_margin_ratio`). The class now exposes only
  core MT5 primitives and single-call convenience wrappers.
- **`tests/test_trading.py`**: Remove all tests for deleted methods.
- **`README.md`**, **`docs/api/trading.md`**, **`docs/api/index.md`**:
  Update to reflect the narrowed API; remove ecosystem boundary tables
  and external-package references.
- **`pyproject.toml`**: Bump version to 1.0.0.

## QA

- `uv run ruff check .` — no findings
- `uv run pyright .` — 0 errors
- `uv run pytest` — 314 passed, 33 skipped, 100% branch coverage

Closes #67