### PR TITLE
Refactor test parametrization

### DIFF
--- a/.agents/skills/pr-feedback-triage/SKILL.md
+++ b/.agents/skills/pr-feedback-triage/SKILL.md
@@ -43,9 +43,10 @@ When a mode disables an action, skip that destructive or externally visible acti
 
 Gather the complete feedback set before editing:
 
-- Fetch unresolved review threads, requested-change reviews, PR-level summary comments, and copied comments.
+- Fetch unresolved review threads, requested-change reviews, inline comments, copied comments, and PR-level summary comments.
 - Use platform-native APIs/CLI when available. Paginate results; do not inspect only the first page of threads or comments.
-- For bot reviewers that post both summary comments and inline comments, collect both. Summary comments often contain severity, rationale, and fix instructions; inline comments contain the exact file and line context.
+- For bot reviewers that post both summary comments and inline comments, prefer inline comments for actionable triage. Incorporate summary findings only when they contain distinct severity, rationale, or fix instructions not already captured from inline comments.
+- Summary comments may be excluded from triage when they do not add distinct actionable context.
 - Preserve every thread/comment identifier needed to reply or resolve later.
 - Compare each comment with the current diff and file contents because review lines can become outdated.
 
@@ -56,7 +57,7 @@ Build one triage record per distinct finding:
 - Prefer exact review-thread identity when available.
 - For duplicate bot findings appearing in both summary and inline comments, merge by exact issue title first, then by file path plus line range as a fallback.
 - Prefer inline comments for location and current code context.
-- Prefer summary comments for severity, category, rationale, and detailed agent prompts.
+- Use summary comments only for distinct severity, category, rationale, or detailed agent prompts that are not already available from inline comments.
 - Preserve the reviewer’s exact issue title and original wording where practical. Do not rename findings in a way that would make replies hard to map back to comments.
 - Preserve the reviewer’s original ordering unless the user asks for priority reordering. Many review bots already order findings by severity.
 
@@ -70,13 +71,20 @@ Keep a thread open only when it still needs reviewer, maintainer, or product inp
 
 When resolving a thread, add a concise reply first only if it provides useful context, such as what changed, why no code change was needed, why a finding was intentionally deferred, or why the original comment is now outdated. Do not add noisy replies for self-evident fixes unless project norms require them.
 
+## Platform Comment Style
+
+- Keep every posted reply or comment brief: one sentence by default, two short sentences only when necessary.
+- Do not post PR-level summary or status comments by default. Omit them when they only restate completed fixes, resolved threads, or verification already visible in commits/checks.
+- Avoid templates, long bullet lists, exhaustive status logs, and duplicated explanations in platform comments.
+- For simple fixes, already-addressed findings, or outdated findings, prefer `resolve_only` over adding a reply.
+
 ## Platform Action Contract
 
-Do not treat triage as complete until every collected source ID reaches an explicit terminal state:
+Do not treat triage as complete until every incorporated source ID reaches an explicit terminal state:
 
 - `resolved`: a platform resolve action succeeded, or a re-check shows the thread is already resolved.
 - `replied_left_open`: a reply or question was posted and the thread is intentionally left unresolved.
-- `not_resolvable`: the source is a PR-level summary comment or copied comment that has no platform-level resolve action; reply or post a PR summary when useful.
+- `not_resolvable`: the source is a PR-level summary comment or copied comment that has no platform-level resolve action; post a brief reply only when useful.
 - `skipped_by_mode`: `dry_run`, `no_push`, or `no_reply` prevented the external action.
 - `failed_action`: a reply or resolve action was attempted and failed; include the attempted action and failure in the final summary.
 
@@ -85,7 +93,7 @@ In normal mode, build and execute a platform action queue after fixes are verifi
 - `reply_then_resolve`: use for handled threads where the reviewer needs context before resolution.
 - `resolve_only`: use for self-evident fixes and already-addressed or outdated threads where an extra reply would add noise.
 - `reply_leave_open`: use only for clarification requests, blocked work, or intentionally open follow-ups.
-- `reply_only`: use for PR-level comments or summaries that cannot be resolved as review threads.
+- `reply_only`: use for PR-level comments or summaries that cannot be resolved, only when a short reply adds value.
 
 For duplicate findings, execute the terminal action for every source thread ID, not only the primary triage record. If one finding is represented by three unresolved inline threads, all three must be resolved or explicitly left open.
 
@@ -150,9 +158,9 @@ flowchart TD
 ## Compact Workflow
 
 1. **Collect all relevant feedback**
-   - Identify the PR and gather unresolved review threads, requested-change reviews, PR-level summaries, inline comments, and copied comments.
+   - Identify the PR and gather unresolved review threads, requested-change reviews, inline comments, copied comments, and PR-level summaries.
    - Paginate all platform calls and keep comment/thread IDs for later replies and resolution.
-   - For bot reviews, collect both summary and inline comments, then merge duplicates rather than fixing the same finding twice.
+   - For bot reviews, prioritize inline comments and incorporate summary findings only when they add distinct actionable context.
 
 2. **Classify each triage record**
    - **Fix**: Valid requested change; make the smallest focused edit when not in `dry_run`.
@@ -168,7 +176,7 @@ flowchart TD
    - In `dry_run`, stop at triage, proposed fixes, suggested replies, and verification plan.
    - In `no_push`, local edits are allowed, but do not push or resolve threads whose fix is only local. Reply or resolve non-code, already-addressed, or outdated threads only when the action does not depend on unpushed work and `no_reply` is not set.
    - In `no_reply`, do not post replies or resolve threads; report suggested replies/actions instead.
-   - In normal mode, commit and push changed code when appropriate, then execute the platform action queue for every collected source ID.
+   - In normal mode, commit and push changed code when appropriate, then execute the platform action queue for every incorporated source ID.
 
 4. **Verify before claiming completion**
    - For fixes, run appropriate checks or explain why they could not run.
@@ -178,15 +186,16 @@ flowchart TD
    - If a resolve or reply operation fails, retry once when safe; then report `failed_action` with the affected source ID and reason.
 
 5. **Finish**
-   - Normal mode: commit/push changes when appropriate, post useful replies or a summary, resolve all handled threads by default, and reconcile the final unresolved set.
+   - Normal mode: commit/push changes when appropriate, post only useful short replies/comments, omit PR-level summaries when they add no value, resolve all handled threads by default, and reconcile the final unresolved set.
    - Safe modes: report the local state and the exact replies/resolution actions a human could take.
 
 ## Reply Guidance
 
-- Keep inline replies short and tied to the original title or concern.
-- For fixed findings, mention the concrete change or commit if useful.
-- For already-addressed or outdated findings, cite the current code path or behavior that makes the finding no longer applicable.
+- Keep inline replies short: one sentence by default, two short sentences only when needed.
+- For fixed findings, mention the concrete change or commit only if it helps the reviewer.
+- For already-addressed or outdated findings, cite the current code path or behavior only as briefly as needed.
 - For deferred or won't-fix findings, provide the reason and any follow-up issue or owner if known.
+- Avoid posting PR-level summary comments unless they communicate a decision, blocker, or requested reviewer action.
 - If a reply or resolve operation fails, continue with the remaining threads and report the failure in the final summary.
 
 ## Final Summary Checklist

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,72 @@
+---
+name: Pull request review and mention bot using OpenCode
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+  pull_request_review_comment:
+    types:
+      - created
+  pull_request_review:
+    types:
+      - submitted
+  issues:
+    types:
+      - opened
+      - assigned
+permissions:
+  contents: read
+jobs:
+  opencode-review:
+    if: >
+      github.event_name == 'pull_request'
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      && (! github.event.pull_request.draft)
+      && (! startsWith(github.head_ref, 'dependabot/'))
+      && (! startsWith(github.head_ref, 'renovate/'))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    uses: dceoy/gh-actions-for-devops/.github/workflows/opencode-review.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      model: opencode-go/glm-5.2
+    secrets:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+  opencode-bot:
+    if: >
+      (
+        (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        && (contains(github.event.comment.body, ' /oc') || contains(github.event.comment.body, ' /opencode'))
+      ) || (
+        github.event_name == 'pull_request_review'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+        && (contains(github.event.review.body, '/oc') || contains(github.event.review.body, '/opencode'))
+      ) || (
+        github.event_name == 'issues'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        && (
+          (contains(github.event.issue.body, '/oc') || contains(github.event.issue.title, '/oc'))
+          || (contains(github.event.issue.body, '/opencode') || contains(github.event.issue.title, '/opencode'))
+        )
+      )
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    uses: dceoy/gh-actions-for-devops/.github/workflows/opencode-review.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      model: opencode-go/glm-5.2
+    secrets:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -36,7 +36,7 @@ jobs:
       actions: read
     uses: dceoy/gh-actions-for-devops/.github/workflows/opencode-review.yml@main  # zizmor: ignore[unpinned-uses]
     with:
-      model: opencode-go/glm-5.2
+      model: opencode-go/kimi-k2.7-code
     secrets:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -45,7 +45,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-        && (contains(github.event.comment.body, ' /oc') || contains(github.event.comment.body, ' /opencode'))
+        && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode'))
       ) || (
         github.event_name == 'pull_request_review'
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
@@ -64,7 +64,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: dceoy/gh-actions-for-devops/.github/workflows/opencode-review.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gh-actions-for-devops/.github/workflows/opencode-bot.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       model: opencode-go/glm-5.2
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code
+.claude/settings.local.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.0.1"
+version = "1.0.2"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1086,10 +1086,31 @@ class TestMt5DataClient:
             getattr(client, method)("EURUSD")
 
     @pytest.mark.parametrize(
-        ("position_id", "call_kwargs", "assert_index", "assert_col"),
+        (
+            "position_id",
+            "call_kwargs",
+            "assert_index",
+            "assert_col",
+            "expected_mt5_args",
+            "expected_mt5_kwargs",
+        ),
         [
-            (0, {"ticket": 123456, "index_keys": "ticket"}, 123456, None),
-            (345678, {"position": 345678}, None, ("position_id", 345678)),
+            (
+                0,
+                {"ticket": 123456, "index_keys": "ticket"},
+                123456,
+                None,
+                (),
+                {"ticket": 123456},
+            ),
+            (
+                345678,
+                {"position": 345678},
+                None,
+                ("position_id", 345678),
+                (),
+                {"position": 345678},
+            ),
             (
                 0,
                 {
@@ -1099,6 +1120,8 @@ class TestMt5DataClient:
                 },
                 None,
                 ("symbol", "EURUSD"),
+                (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)),
+                {"group": "*EURUSD*"},
             ),
             (
                 0,
@@ -1109,6 +1132,8 @@ class TestMt5DataClient:
                 },
                 None,
                 ("symbol", "EURUSD"),
+                (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)),
+                {"group": "*USD*"},
             ),
         ],
         ids=["ticket", "position", "symbol", "group"],
@@ -1120,6 +1145,8 @@ class TestMt5DataClient:
         call_kwargs: dict[str, Any],
         assert_index: int | None,
         assert_col: tuple[str, Any] | None,
+        expected_mt5_args: tuple[Any, ...],
+        expected_mt5_kwargs: dict[str, Any],
     ) -> None:
         """Test history_orders_get_as_df with various filter kwargs."""
         assert mock_mt5_import is not None
@@ -1165,6 +1192,9 @@ class TestMt5DataClient:
             assert assert_col is not None
             col, val = assert_col
             assert df_result.iloc[0][col] == val
+        mock_mt5_import.history_orders_get.assert_called_once_with(
+            *expected_mt5_args, **expected_mt5_kwargs
+        )
 
     def test_history_orders_get_no_dates(
         self, mock_mt5_import: ModuleType | None
@@ -2049,10 +2079,28 @@ class TestMt5DataClientRetryLogic:
             client._validate_history_input(**kwargs)  # type: ignore[reportPrivateUsage]
 
     @pytest.mark.parametrize(
-        ("call_kwargs", "assert_index", "assert_col"),
+        (
+            "call_kwargs",
+            "assert_index",
+            "assert_col",
+            "expected_mt5_args",
+            "expected_mt5_kwargs",
+        ),
         [
-            ({"ticket": 123456, "index_keys": "ticket"}, 123456, None),
-            ({"position": 345678}, None, ("position_id", 345678)),
+            (
+                {"ticket": 123456, "index_keys": "ticket"},
+                123456,
+                None,
+                (),
+                {"ticket": 123456},
+            ),
+            (
+                {"position": 345678},
+                None,
+                ("position_id", 345678),
+                (),
+                {"position": 345678},
+            ),
             (
                 {
                     "date_from": datetime(2022, 1, 1, tzinfo=UTC),
@@ -2061,6 +2109,8 @@ class TestMt5DataClientRetryLogic:
                 },
                 None,
                 ("symbol", "EURUSD"),
+                (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)),
+                {"group": "*EURUSD*"},
             ),
             (
                 {
@@ -2070,6 +2120,8 @@ class TestMt5DataClientRetryLogic:
                 },
                 None,
                 ("symbol", "EURUSD"),
+                (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)),
+                {"group": "*USD*"},
             ),
         ],
         ids=["ticket", "position", "symbol", "group"],
@@ -2080,6 +2132,8 @@ class TestMt5DataClientRetryLogic:
         call_kwargs: dict[str, Any],
         assert_index: int | None,
         assert_col: tuple[str, Any] | None,
+        expected_mt5_args: tuple[Any, ...],
+        expected_mt5_kwargs: dict[str, Any],
     ) -> None:
         """Test history_deals_get_as_df with ticket or position filter."""
         assert mock_mt5_import is not None
@@ -2119,6 +2173,9 @@ class TestMt5DataClientRetryLogic:
             assert assert_col is not None
             col, val = assert_col
             assert df_result.iloc[0][col] == val
+        mock_mt5_import.history_deals_get.assert_called_once_with(
+            *expected_mt5_args, **expected_mt5_kwargs
+        )
 
     def test_context_manager_with_exception(
         self, mock_mt5_import: ModuleType | None

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -850,130 +850,76 @@ class TestMt5DataClient:
 
         assert result == pytest.approx(10.0)
 
-    def test_order_calc_profit_invalid_volume(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        "args",
+        [
+            (0, "EURUSD", 0.0, 1.1300, 1.1400),
+            (0, "EURUSD", 0.1, 0.0, 1.1400),
+            (0, "EURUSD", 0.1, 1.1300, 0.0),
+            (0, "EURUSD", 0.1, 1.1300, 1.1400),
+        ],
+    )
+    def test_order_calc_profit_returns_none(
+        self,
+        mock_mt5_import: ModuleType | None,
+        args: tuple[int, str, float, float, float],
     ) -> None:
-        """Test order_calc_profit method with invalid volume."""
+        """Test order_calc_profit raises when MT5 returns None."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
         mock_mt5_import.order_calc_profit.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Invalid volume")
+        mock_mt5_import.last_error.return_value = (1, "error")
 
         client = create_initialized_client(mock_mt5_import)
         with pytest.raises(
             Mt5RuntimeError, match=r"MT5 order_calc_profit returned None"
         ):
-            client.order_calc_profit(0, "EURUSD", 0.0, 1.1300, 1.1400)
+            client.order_calc_profit(*args)
 
-    def test_order_calc_profit_invalid_price_open(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        "return_value",
+        [(2460, 2460, "15 Feb 2022"), None],
+    )
+    def test_version(
+        self,
+        mock_mt5_import: ModuleType | None,
+        return_value: tuple[int, int, str] | None,
     ) -> None:
-        """Test order_calc_profit method with invalid open price."""
+        """Test version with a value and None."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.order_calc_profit.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Invalid price_open")
-
-        client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(
-            Mt5RuntimeError, match=r"MT5 order_calc_profit returned None"
-        ):
-            client.order_calc_profit(0, "EURUSD", 0.1, 0.0, 1.1400)
-
-    def test_order_calc_profit_invalid_price_close(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test order_calc_profit method with invalid close price."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.order_calc_profit.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Invalid price_close")
-
-        client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(
-            Mt5RuntimeError, match=r"MT5 order_calc_profit returned None"
-        ):
-            client.order_calc_profit(0, "EURUSD", 0.1, 1.1300, 0.0)
-
-    def test_order_calc_profit_error(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test order_calc_profit method with error."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.order_calc_profit.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Order calc profit failed")
-
-        client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(
-            Mt5RuntimeError,
-            match=r"MT5 order_calc_profit returned None",
-        ):
-            client.order_calc_profit(0, "EURUSD", 0.1, 1.1300, 1.1400)
-
-    def test_version(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test version method."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.version.return_value = (2460, 2460, "15 Feb 2022")
+        mock_mt5_import.version.return_value = return_value
 
         client = create_initialized_client(mock_mt5_import)
         result = client.version()
 
-        assert result == (2460, 2460, "15 Feb 2022")
+        assert result == return_value
 
-    def test_version_none_result(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test version method with None result."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.version.return_value = None
-
-        client = create_initialized_client(mock_mt5_import)
-        result = client.version()
-
-        assert result is None
-
-    def test_symbols_total(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test symbols_total method."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.symbols_total.return_value = 1000
-
-        client = create_initialized_client(mock_mt5_import)
-        result = client.symbols_total()
-
-        assert result == 1000
-
-    def test_symbols_total_none_result(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize("return_value", [1000, None])
+    def test_symbols_total(
+        self, mock_mt5_import: ModuleType | None, return_value: int | None
     ) -> None:
-        """Test symbols_total method with None result."""
+        """Test symbols_total with a value and None."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.symbols_total.return_value = None
+        mock_mt5_import.symbols_total.return_value = return_value
 
         client = create_initialized_client(mock_mt5_import)
         result = client.symbols_total()
 
-        assert result is None
+        assert result == return_value
 
-    def test_symbol_select(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test symbol_select method."""
+    @pytest.mark.parametrize("enable", [True, False])
+    def test_symbol_select(
+        self, mock_mt5_import: ModuleType | None, enable: bool
+    ) -> None:
+        """Test symbol_select with and without enable flag."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
         mock_mt5_import.symbol_select.return_value = True
 
         client = create_initialized_client(mock_mt5_import)
-        result = client.symbol_select("EURUSD")
-
-        assert result is True
-
-    def test_symbol_select_disable(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test symbol_select method with disable."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.symbol_select.return_value = True
-
-        client = create_initialized_client(mock_mt5_import)
-        result = client.symbol_select("EURUSD", enable=False)
+        result = client.symbol_select("EURUSD", enable=enable)
 
         assert result is True
 
@@ -988,54 +934,33 @@ class TestMt5DataClient:
         with pytest.raises(Mt5RuntimeError, match=r"MT5 symbol_select returned None"):
             client.symbol_select("EURUSD")
 
-    def test_market_book_add(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test market_book_add method."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.market_book_add.return_value = True
-
-        client = create_initialized_client(mock_mt5_import)
-        result = client.market_book_add("EURUSD")
-
-        assert result is True
-
-    def test_market_book_add_error(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test market_book_add method with error."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.market_book_add.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Market book add failed")
-
-        client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(Mt5RuntimeError, match=r"MT5 market_book_add returned None"):
-            client.market_book_add("EURUSD")
-
-    def test_market_book_release(self, mock_mt5_import: ModuleType | None) -> None:
-        """Test market_book_release method."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.market_book_release.return_value = True
-
-        client = create_initialized_client(mock_mt5_import)
-        result = client.market_book_release("EURUSD")
-
-        assert result is True
-
-    def test_market_book_release_error(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize("method", ["market_book_add", "market_book_release"])
+    def test_market_book_actions_success(
+        self, mock_mt5_import: ModuleType | None, method: str
     ) -> None:
-        """Test market_book_release method with error."""
+        """Test market_book_add/release success."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.market_book_release.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "Market book release failed")
+        getattr(mock_mt5_import, method).return_value = True
 
         client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(
-            Mt5RuntimeError,
-            match=r"MT5 market_book_release returned None",
-        ):
-            client.market_book_release("EURUSD")
+        result = getattr(client, method)("EURUSD")
+
+        assert result is True
+
+    @pytest.mark.parametrize("method", ["market_book_add", "market_book_release"])
+    def test_market_book_actions_error(
+        self, mock_mt5_import: ModuleType | None, method: str
+    ) -> None:
+        """Test market_book_add/release error."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        getattr(mock_mt5_import, method).return_value = None
+        mock_mt5_import.last_error.return_value = (1, f"{method} failed")
+
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(Mt5RuntimeError, match=rf"MT5 {method} returned None"):
+            getattr(client, method)("EURUSD")
 
     def test_history_orders_get_ticket(
         self, mock_mt5_import: ModuleType | None
@@ -1483,30 +1408,25 @@ class TestMt5DataClient:
 class TestMt5DataClientValidation:
     """Test Mt5DataClient validation methods."""
 
-    def test_validate_positive_count_valid(self) -> None:
-        """Test _validate_positive_count with valid count."""
-        # Should not raise for positive count
+    @pytest.mark.parametrize("count", [1, 100])
+    def test_validate_positive_count_valid(self, count: int) -> None:
+        """Test _validate_positive_count with valid counts."""
         Mt5DataClient._validate_positive_count(  # type: ignore[reportPrivateUsage]
-            count=1
-        )
-        Mt5DataClient._validate_positive_count(  # type: ignore[reportPrivateUsage]
-            count=100
+            count=count
         )
 
-    def test_validate_positive_count_invalid(self) -> None:
-        """Test _validate_positive_count with invalid count."""
-        with pytest.raises(
-            ValueError, match=r"Invalid count: 0\. Count must be positive\."
-        ):
+    @pytest.mark.parametrize(
+        ("count", "match"),
+        [
+            (0, r"Invalid count: 0\. Count must be positive\."),
+            (-1, r"Invalid count: -1\. Count must be positive\."),
+        ],
+    )
+    def test_validate_positive_count_invalid(self, count: int, match: str) -> None:
+        """Test _validate_positive_count with invalid counts."""
+        with pytest.raises(ValueError, match=match):
             Mt5DataClient._validate_positive_count(  # type: ignore[reportPrivateUsage]
-                count=0
-            )
-
-        with pytest.raises(
-            ValueError, match=r"Invalid count: -1\. Count must be positive\."
-        ):
-            Mt5DataClient._validate_positive_count(  # type: ignore[reportPrivateUsage]
-                count=-1
+                count=count
             )
 
     def test_validate_date_range_valid(self) -> None:
@@ -1529,62 +1449,44 @@ class TestMt5DataClientValidation:
                 date_from=date_from, date_to=date_to
             )
 
-    def test_validate_positive_value_valid(self) -> None:
+    @pytest.mark.parametrize(
+        ("value", "name"),
+        [
+            (1.0, "volume"),
+            (0.1, "volume"),
+        ],
+    )
+    def test_validate_positive_value_valid(self, value: float, name: str) -> None:
         """Test _validate_positive_value with valid values."""
-        # Should not raise for positive values
         Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-            value=1.0,
-            name="volume",
-        )
-        Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-            value=0.1,
-            name="volume",
+            value=value,
+            name=name,
         )
 
-    def test_validate_positive_value_invalid(self) -> None:
-        """Test _validate_positive_value with invalid volume."""
-        with pytest.raises(
-            ValueError, match=r"Invalid volume: 0\. Volume must be positive\."
-        ):
+    @pytest.mark.parametrize(
+        ("value", "name", "match"),
+        [
+            (0, "volume", r"Invalid volume: 0\. Volume must be positive\."),
+            (-1, "volume", r"Invalid volume: -1\. Volume must be positive\."),
+            (0, "price_open", r"Invalid price_open: 0\. Price must be positive\."),
+            (-1, "price_close", r"Invalid price_close: -1\. Price must be positive\."),
+        ],
+    )
+    def test_validate_positive_value_invalid(
+        self, value: int, name: str, match: str
+    ) -> None:
+        """Test _validate_positive_value with invalid values."""
+        with pytest.raises(ValueError, match=match):
             Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-                value=0,
-                name="volume",
+                value=value,
+                name=name,
             )
 
-        with pytest.raises(
-            ValueError, match=r"Invalid volume: -1\. Volume must be positive\."
-        ):
-            Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-                value=-1,
-                name="volume",
-            )
-
-    def test_validate_positive_value_price_invalid(self) -> None:
-        """Test _validate_positive_value with invalid price."""
-        with pytest.raises(
-            ValueError, match=r"Invalid price_open: 0\. Price must be positive\."
-        ):
-            Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-                value=0,
-                name="price_open",
-            )
-
-        with pytest.raises(
-            ValueError, match=r"Invalid price_close: -1\. Price must be positive\."
-        ):
-            Mt5DataClient._validate_positive_value(  # type: ignore[reportPrivateUsage]
-                value=-1,
-                name="price_close",
-            )
-
-    def test_validate_non_negative_position_valid(self) -> None:
-        """Test _validate_non_negative_position with valid position."""
-        # Should not raise for non-negative position
+    @pytest.mark.parametrize("position", [0, 10])
+    def test_validate_non_negative_position_valid(self, position: int) -> None:
+        """Test _validate_non_negative_position with valid positions."""
         Mt5DataClient._validate_non_negative_position(  # type: ignore[reportPrivateUsage]
-            position=0
-        )
-        Mt5DataClient._validate_non_negative_position(  # type: ignore[reportPrivateUsage]
-            position=10
+            position=position
         )
 
     def test_validate_non_negative_position_invalid(self) -> None:
@@ -2084,51 +1986,43 @@ class TestMt5DataClientRetryLogic:
         # last_error is called multiple times (in decorators and explicitly)
         assert mock_mt5_import.last_error.call_count >= 1
 
-    def test_validate_history_input_with_ticket(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"ticket": 123456},
+            {"position": 789012},
+            {
+                "date_from": datetime(2022, 1, 1, tzinfo=UTC),
+                "date_to": datetime(2022, 1, 2, tzinfo=UTC),
+            },
+        ],
+    )
+    def test_validate_history_input_valid(
+        self,
+        mock_mt5_import: ModuleType | None,
+        kwargs: dict[str, Any],
     ) -> None:
-        """Test _validate_history_input with ticket parameter."""
+        """Test _validate_history_input with valid inputs."""
         assert mock_mt5_import is not None
         client = create_initialized_client(mock_mt5_import)
+        client._validate_history_input(**kwargs)  # type: ignore[reportPrivateUsage]
 
-        # Should not raise when ticket is provided
-        client._validate_history_input(  # type: ignore[reportPrivateUsage]
-            ticket=123456
-        )
-
-    def test_validate_history_input_with_position(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"date_from": datetime(2022, 1, 1, tzinfo=UTC)},
+            {"date_to": datetime(2022, 1, 2, tzinfo=UTC)},
+            {},
+        ],
+    )
+    def test_validate_history_input_invalid(
+        self,
+        mock_mt5_import: ModuleType | None,
+        kwargs: dict[str, Any],
     ) -> None:
-        """Test _validate_history_input with position parameter."""
+        """Test _validate_history_input rejects incomplete date inputs."""
         assert mock_mt5_import is not None
         client = create_initialized_client(mock_mt5_import)
-
-        # Should not raise when position is provided
-        client._validate_history_input(  # type: ignore[reportPrivateUsage]
-            position=789012
-        )
-
-    def test_validate_history_input_with_dates(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test _validate_history_input with date parameters."""
-        assert mock_mt5_import is not None
-        client = create_initialized_client(mock_mt5_import)
-
-        # Should not raise when both dates are provided
-        client._validate_history_input(  # type: ignore[reportPrivateUsage]
-            date_from=datetime(2022, 1, 1, tzinfo=UTC),
-            date_to=datetime(2022, 1, 2, tzinfo=UTC),
-        )
-
-    def test_validate_history_input_missing_date_to(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test _validate_history_input with missing date_to."""
-        assert mock_mt5_import is not None
-        client = create_initialized_client(mock_mt5_import)
-
-        # Should raise when only date_from is provided
         with pytest.raises(
             ValueError,
             match=(
@@ -2136,45 +2030,7 @@ class TestMt5DataClientRetryLogic:
                 r" if not using ticket or position"
             ),
         ):
-            client._validate_history_input(  # type: ignore[reportPrivateUsage]
-                date_from=datetime(2022, 1, 1, tzinfo=UTC)
-            )
-
-    def test_validate_history_input_missing_date_from(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test _validate_history_input with missing date_from."""
-        assert mock_mt5_import is not None
-        client = create_initialized_client(mock_mt5_import)
-
-        # Should raise when only date_to is provided
-        with pytest.raises(
-            ValueError,
-            match=(
-                r"Both date_from and date_to must be provided"
-                r" if not using ticket or position"
-            ),
-        ):
-            client._validate_history_input(  # type: ignore[reportPrivateUsage]
-                date_to=datetime(2022, 1, 2, tzinfo=UTC)
-            )
-
-    def test_validate_history_input_no_params(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test _validate_history_input with no parameters."""
-        assert mock_mt5_import is not None
-        client = create_initialized_client(mock_mt5_import)
-
-        # Should raise when no parameters are provided
-        with pytest.raises(
-            ValueError,
-            match=(
-                r"Both date_from and date_to must be provided"
-                r" if not using ticket or position"
-            ),
-        ):
-            client._validate_history_input()  # type: ignore[reportPrivateUsage]
+            client._validate_history_input(**kwargs)  # type: ignore[reportPrivateUsage]
 
     def test_history_deals_get_ticket_only(
         self, mock_mt5_import: ModuleType | None
@@ -2651,8 +2507,39 @@ class TestMt5DataClientCoverageMissing:
         assert result[0]["price"] == pytest.approx(1.1300)
         assert result[0]["type"] == 0
 
-    def test_copy_rates_from_as_dicts(self, mock_mt5_import: ModuleType) -> None:
-        """Test copy_rates_from_as_dicts method."""
+    @pytest.mark.parametrize(
+        ("mt5_method", "client_method", "args"),
+        [
+            (
+                "copy_rates_from",
+                "copy_rates_from_as_dicts",
+                ("EURUSD", 16385, datetime(2023, 1, 1, tzinfo=UTC), 10),
+            ),
+            (
+                "copy_rates_from_pos",
+                "copy_rates_from_pos_as_dicts",
+                ("EURUSD", 16385, 0, 10),
+            ),
+            (
+                "copy_rates_range",
+                "copy_rates_range_as_dicts",
+                (
+                    "EURUSD",
+                    16385,
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 2, tzinfo=UTC),
+                ),
+            ),
+        ],
+    )
+    def test_copy_rates_as_dicts(
+        self,
+        mock_mt5_import: ModuleType,
+        mt5_method: str,
+        client_method: str,
+        args: tuple[object, ...],
+    ) -> None:
+        """Test copy_rates_*_as_dicts with and without datetime conversion."""
         rate_dtype = np.dtype([
             ("time", "int64"),
             ("open", "float64"),
@@ -2664,86 +2551,46 @@ class TestMt5DataClientCoverageMissing:
             [(1640995200, 1.1300, 1.1350, 1.1280, 1.1320)],
             dtype=rate_dtype,
         )
-        mock_mt5_import.copy_rates_from.return_value = mock_rates
+        getattr(mock_mt5_import, mt5_method).return_value = mock_rates
         client = create_initialized_client(mock_mt5_import)
 
-        # Test without convert_time
-        result = client.copy_rates_from_as_dicts(
-            "EURUSD", 16385, datetime(2023, 1, 1, tzinfo=UTC), 10, skip_to_datetime=True
-        )
+        result = getattr(client, client_method)(*args, skip_to_datetime=True)
         assert len(result) == 1
         assert result[0]["time"] == 1640995200
         assert isinstance(result[0]["time"], int)
 
-        # Test with convert_time (default True)
-        result = client.copy_rates_from_as_dicts(
-            "EURUSD", 16385, datetime(2023, 1, 1, tzinfo=UTC), 10
-        )
+        result = getattr(client, client_method)(*args)
         assert len(result) == 1
         assert "time" in result[0]
 
-    def test_copy_rates_from_pos_as_dicts(self, mock_mt5_import: ModuleType) -> None:
-        """Test copy_rates_from_pos_as_dicts method."""
-        rate_dtype = np.dtype([
-            ("time", "int64"),
-            ("open", "float64"),
-            ("high", "float64"),
-            ("low", "float64"),
-            ("close", "float64"),
-        ])
-        mock_rates = np.array(
-            [(1640995200, 1.1300, 1.1350, 1.1280, 1.1320)],
-            dtype=rate_dtype,
-        )
-        mock_mt5_import.copy_rates_from_pos.return_value = mock_rates
-        client = create_initialized_client(mock_mt5_import)
-
-        # Test without convert_time
-        result = client.copy_rates_from_pos_as_dicts(
-            "EURUSD", 16385, 0, 10, skip_to_datetime=True
-        )
-        assert len(result) == 1
-        assert result[0]["time"] == 1640995200
-        assert isinstance(result[0]["time"], int)
-
-        # Test with convert_time (default True)
-        result = client.copy_rates_from_pos_as_dicts("EURUSD", 16385, 0, 10)
-        assert len(result) == 1
-        assert "time" in result[0]
-
-    def test_copy_rates_range_as_dicts(self, mock_mt5_import: ModuleType) -> None:
-        """Test copy_rates_range_as_dicts method."""
-        rate_dtype = np.dtype([
-            ("time", "int64"),
-            ("open", "float64"),
-            ("high", "float64"),
-            ("low", "float64"),
-            ("close", "float64"),
-        ])
-        mock_rates = np.array(
-            [(1640995200, 1.1300, 1.1350, 1.1280, 1.1320)],
-            dtype=rate_dtype,
-        )
-        mock_mt5_import.copy_rates_range.return_value = mock_rates
-        client = create_initialized_client(mock_mt5_import)
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 2, tzinfo=UTC)
-
-        # Test without convert_time
-        result = client.copy_rates_range_as_dicts(
-            "EURUSD", 16385, date_from, date_to, skip_to_datetime=True
-        )
-        assert len(result) == 1
-        assert result[0]["time"] == 1640995200
-        assert isinstance(result[0]["time"], int)
-
-        # Test with convert_time (default True)
-        result = client.copy_rates_range_as_dicts("EURUSD", 16385, date_from, date_to)
-        assert len(result) == 1
-        assert "time" in result[0]
-
-    def test_copy_ticks_from_as_dicts(self, mock_mt5_import: ModuleType) -> None:
-        """Test copy_ticks_from_as_dicts method."""
+    @pytest.mark.parametrize(
+        ("mt5_method", "client_method", "args"),
+        [
+            (
+                "copy_ticks_from",
+                "copy_ticks_from_as_dicts",
+                ("EURUSD", datetime(2023, 1, 1, tzinfo=UTC), 10, 0),
+            ),
+            (
+                "copy_ticks_range",
+                "copy_ticks_range_as_dicts",
+                (
+                    "EURUSD",
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 2, tzinfo=UTC),
+                    0,
+                ),
+            ),
+        ],
+    )
+    def test_copy_ticks_as_dicts(
+        self,
+        mock_mt5_import: ModuleType,
+        mt5_method: str,
+        client_method: str,
+        args: tuple[object, ...],
+    ) -> None:
+        """Test copy_ticks_*_as_dicts with and without datetime conversion."""
         tick_dtype = np.dtype([
             ("time", "int64"),
             ("bid", "float64"),
@@ -2758,56 +2605,15 @@ class TestMt5DataClientCoverageMissing:
             [(1640995200, 1.1300, 1.1301, 0, 0, 1640995200000, 0, 0)],
             dtype=tick_dtype,
         )
-        mock_mt5_import.copy_ticks_from.return_value = mock_ticks
+        getattr(mock_mt5_import, mt5_method).return_value = mock_ticks
         client = create_initialized_client(mock_mt5_import)
 
-        # Test without convert_time
-        result = client.copy_ticks_from_as_dicts(
-            "EURUSD", datetime(2023, 1, 1, tzinfo=UTC), 10, 0, skip_to_datetime=True
-        )
+        result = getattr(client, client_method)(*args, skip_to_datetime=True)
         assert len(result) == 1
         assert result[0]["time"] == 1640995200
         assert isinstance(result[0]["time"], int)
 
-        # Test with convert_time (default True)
-        result = client.copy_ticks_from_as_dicts(
-            "EURUSD", datetime(2023, 1, 1, tzinfo=UTC), 10, 0
-        )
-        assert len(result) == 1
-        assert "time" in result[0]
-        assert "time_msc" in result[0]
-
-    def test_copy_ticks_range_as_dicts(self, mock_mt5_import: ModuleType) -> None:
-        """Test copy_ticks_range_as_dicts method."""
-        tick_dtype = np.dtype([
-            ("time", "int64"),
-            ("bid", "float64"),
-            ("ask", "float64"),
-            ("last", "float64"),
-            ("volume", "uint64"),
-            ("time_msc", "int64"),
-            ("flags", "uint32"),
-            ("volume_real", "float64"),
-        ])
-        mock_ticks = np.array(
-            [(1640995200, 1.1300, 1.1301, 0, 0, 1640995200000, 0, 0)],
-            dtype=tick_dtype,
-        )
-        mock_mt5_import.copy_ticks_range.return_value = mock_ticks
-        client = create_initialized_client(mock_mt5_import)
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 2, tzinfo=UTC)
-
-        # Test without convert_time
-        result = client.copy_ticks_range_as_dicts(
-            "EURUSD", date_from, date_to, 0, skip_to_datetime=True
-        )
-        assert len(result) == 1
-        assert result[0]["time"] == 1640995200
-        assert isinstance(result[0]["time"], int)
-
-        # Test with convert_time (default True)
-        result = client.copy_ticks_range_as_dicts("EURUSD", date_from, date_to, 0)
+        result = getattr(client, client_method)(*args)
         assert len(result) == 1
         assert "time" in result[0]
         assert "time_msc" in result[0]
@@ -3282,6 +3088,7 @@ class TestMt5DataClientCoverageMissing:
         assert len(result) == 1
         assert isinstance(result[0], dict)
         assert "time" in result[0]
+        assert isinstance(result[0]["time"], pd.Timestamp)
 
     def test_detect_and_convert_time_decorator_non_dict_object(
         self,

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -253,6 +253,7 @@ class MockSymbolInfo(NamedTuple):
     path: str
 
 
+# Shared minimal symbol info fixture reused across symbol-related tests.
 _MOCK_SYMBOL_INFO = MockSymbolInfo(
     custom=False,
     chart_mode=0,
@@ -2066,7 +2067,7 @@ class TestMt5DataClientRetryLogic:
         mock_mt5_import: ModuleType | None,
         kwargs: dict[str, Any],
     ) -> None:
-        """Test _validate_history_input rejects incomplete date inputs."""
+        """Test _validate_history_input rejects missing or incomplete date inputs."""
         assert mock_mt5_import is not None
         client = create_initialized_client(mock_mt5_import)
         with pytest.raises(
@@ -2135,7 +2136,7 @@ class TestMt5DataClientRetryLogic:
         expected_mt5_args: tuple[Any, ...],
         expected_mt5_kwargs: dict[str, Any],
     ) -> None:
-        """Test history_deals_get_as_df with ticket or position filter."""
+        """Test history_deals_get_as_df with ticket, position, symbol, or group."""
         assert mock_mt5_import is not None
         mock_deals = [
             MockDeal(
@@ -2393,8 +2394,8 @@ class TestMt5DataClientCoverageMissing:
             ),
             (
                 {"level1": {"level2": {"level3": "value"}}, "simple": "value2"},
-                {"sep": "_"},
-                {"level1_level2": {"level3": "value"}, "simple": "value2"},
+                {"sep": "-"},
+                {"level1-level2": {"level3": "value"}, "simple": "value2"},
             ),
         ],
         ids=["simple", "nested", "custom_separator"],

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -253,6 +253,106 @@ class MockSymbolInfo(NamedTuple):
     path: str
 
 
+_MOCK_SYMBOL_INFO = MockSymbolInfo(
+    custom=False,
+    chart_mode=0,
+    select=True,
+    visible=True,
+    session_deals=0,
+    session_buy_orders=0,
+    session_sell_orders=0,
+    volume=0,
+    volumehigh=0,
+    volumelow=0,
+    time=1640995200,
+    digits=5,
+    spread=10,
+    spread_float=True,
+    ticks_bookdepth=10,
+    trade_calc_mode=0,
+    trade_mode=4,
+    start_time=0,
+    expiration_time=0,
+    trade_stops_level=0,
+    trade_freeze_level=0,
+    trade_exemode=1,
+    swap_mode=1,
+    swap_rollover3days=3,
+    margin_hedged_use_leg=False,
+    expiration_mode=7,
+    filling_mode=1,
+    order_mode=127,
+    order_gtc_mode=0,
+    option_mode=0,
+    option_right=0,
+    bid=1.13200,
+    bidhigh=1.13500,
+    bidlow=1.13000,
+    ask=1.13210,
+    askhigh=1.13510,
+    asklow=1.13010,
+    last=1.13205,
+    lasthigh=1.13505,
+    lastlow=1.13005,
+    volume_real=1000000.0,
+    volumehigh_real=2000000.0,
+    volumelow_real=500000.0,
+    option_strike=0.0,
+    point=0.00001,
+    trade_tick_value=1.0,
+    trade_tick_value_profit=1.0,
+    trade_tick_value_loss=1.0,
+    trade_tick_size=0.00001,
+    trade_contract_size=100000.0,
+    trade_accrued_interest=0.0,
+    trade_face_value=0.0,
+    trade_liquidity_rate=0.0,
+    volume_min=0.01,
+    volume_max=500.0,
+    volume_step=0.01,
+    volume_limit=0.0,
+    swap_long=-0.5,
+    swap_short=-0.3,
+    margin_initial=0.0,
+    margin_maintenance=0.0,
+    session_volume=0.0,
+    session_turnover=0.0,
+    session_interest=0.0,
+    session_buy_orders_volume=0.0,
+    session_sell_orders_volume=0.0,
+    session_open=1.13100,
+    session_close=1.13200,
+    session_aw=0.0,
+    session_price_settlement=0.0,
+    session_price_limit_min=0.0,
+    session_price_limit_max=0.0,
+    margin_hedged=50000.0,
+    price_change=0.0010,
+    price_volatility=0.0,
+    price_theoretical=0.0,
+    price_greeks_delta=0.0,
+    price_greeks_theta=0.0,
+    price_greeks_gamma=0.0,
+    price_greeks_vega=0.0,
+    price_greeks_rho=0.0,
+    price_greeks_omega=0.0,
+    price_sensitivity=0.0,
+    basis="",
+    category="",
+    currency_base="EUR",
+    currency_profit="USD",
+    currency_margin="USD",
+    bank="",
+    description="Euro vs US Dollar",
+    exchange="",
+    formula="",
+    isin="",
+    name="EURUSD",
+    page="",
+    path="Forex\\Majors\\EURUSD",
+)
+
+
 class MockTick(NamedTuple):
     """Mock tick structure."""
 
@@ -962,10 +1062,43 @@ class TestMt5DataClient:
         with pytest.raises(Mt5RuntimeError, match=rf"MT5 {method} returned None"):
             getattr(client, method)("EURUSD")
 
-    def test_history_orders_get_ticket(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        ("position_id", "call_kwargs", "assert_index", "assert_col"),
+        [
+            (0, {"ticket": 123456, "index_keys": "ticket"}, 123456, None),
+            (345678, {"position": 345678}, None, ("position_id", 345678)),
+            (
+                0,
+                {
+                    "date_from": datetime(2022, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2022, 1, 2, tzinfo=UTC),
+                    "symbol": "EURUSD",
+                },
+                None,
+                ("symbol", "EURUSD"),
+            ),
+            (
+                0,
+                {
+                    "date_from": datetime(2022, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2022, 1, 2, tzinfo=UTC),
+                    "group": "*USD*",
+                },
+                None,
+                ("symbol", "EURUSD"),
+            ),
+        ],
+        ids=["ticket", "position", "symbol", "group"],
+    )
+    def test_history_orders_get_filters(
+        self,
+        mock_mt5_import: ModuleType | None,
+        position_id: int,
+        call_kwargs: dict[str, Any],
+        assert_index: int | None,
+        assert_col: tuple[str, Any] | None,
     ) -> None:
-        """Test history_orders_get method with ticket filter."""
+        """Test history_orders_get_as_df with various filter kwargs."""
         assert mock_mt5_import is not None
         mock_orders = [
             MockOrder(
@@ -980,7 +1113,7 @@ class TestMt5DataClient:
                 type_filling=0,
                 state=1,
                 magic=0,
-                position_id=0,
+                position_id=position_id,
                 position_by_id=0,
                 reason=0,
                 volume_initial=0.1,
@@ -995,62 +1128,20 @@ class TestMt5DataClient:
                 external_id="",
             ),
         ]
-
         client = Mt5DataClient(mt5=mock_mt5_import)
         mock_mt5_import.initialize.return_value = True
         mock_mt5_import.history_orders_get.return_value = mock_orders
-
         client.initialize()
-        df_result = client.history_orders_get_as_df(ticket=123456, index_keys="ticket")
+        df_result = client.history_orders_get_as_df(**call_kwargs)
 
         assert isinstance(df_result, pd.DataFrame)
         assert len(df_result) == 1
-        assert df_result.index[0] == 123456
-
-    def test_history_orders_get_position(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_orders_get method with position filter."""
-        assert mock_mt5_import is not None
-        mock_orders = [
-            MockOrder(
-                ticket=123456,
-                time_setup=1640995200,
-                time_setup_msc=1640995200000,
-                time_done=0,
-                time_done_msc=0,
-                time_expiration=0,
-                type=0,
-                type_time=0,
-                type_filling=0,
-                state=1,
-                magic=0,
-                position_id=345678,
-                position_by_id=0,
-                reason=0,
-                volume_initial=0.1,
-                volume_current=0.1,
-                price_open=1.1300,
-                sl=1.1200,
-                tp=1.1400,
-                price_current=1.1301,
-                price_stoplimit=0.0,
-                symbol="EURUSD",
-                comment="",
-                external_id="",
-            ),
-        ]
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_orders_get.return_value = mock_orders
-
-        client.initialize()
-        df_result = client.history_orders_get_as_df(position=345678)
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert df_result.iloc[0]["position_id"] == 345678
+        if assert_index is not None:
+            assert df_result.index[0] == assert_index
+        else:
+            assert assert_col is not None
+            col, val = assert_col
+            assert df_result.iloc[0][col] == val
 
     def test_history_orders_get_no_dates(
         self, mock_mt5_import: ModuleType | None
@@ -1082,104 +1173,6 @@ class TestMt5DataClient:
                 datetime(2022, 1, 2, tzinfo=UTC),
                 datetime(2022, 1, 1, tzinfo=UTC),
             )
-
-    def test_history_orders_get_with_symbol(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_orders_get method with symbol filter."""
-        assert mock_mt5_import is not None
-        mock_orders = [
-            MockOrder(
-                ticket=123456,
-                time_setup=1640995200,
-                time_setup_msc=1640995200000,
-                time_done=0,
-                time_done_msc=0,
-                time_expiration=0,
-                type=0,
-                type_time=0,
-                type_filling=0,
-                state=1,
-                magic=0,
-                position_id=0,
-                position_by_id=0,
-                reason=0,
-                volume_initial=0.1,
-                volume_current=0.1,
-                price_open=1.1300,
-                sl=1.1200,
-                tp=1.1400,
-                price_current=1.1301,
-                price_stoplimit=0.0,
-                symbol="EURUSD",
-                comment="",
-                external_id="",
-            ),
-        ]
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_orders_get.return_value = mock_orders
-
-        client.initialize()
-        df_result = client.history_orders_get_as_df(
-            datetime(2022, 1, 1, tzinfo=UTC),
-            datetime(2022, 1, 2, tzinfo=UTC),
-            symbol="EURUSD",
-        )
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert df_result.iloc[0]["symbol"] == "EURUSD"
-
-    def test_history_orders_get_with_group(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_orders_get method with group filter."""
-        assert mock_mt5_import is not None
-        mock_orders = [
-            MockOrder(
-                ticket=123456,
-                time_setup=1640995200,
-                time_setup_msc=1640995200000,
-                time_done=0,
-                time_done_msc=0,
-                time_expiration=0,
-                type=0,
-                type_time=0,
-                type_filling=0,
-                state=1,
-                magic=0,
-                position_id=0,
-                position_by_id=0,
-                reason=0,
-                volume_initial=0.1,
-                volume_current=0.1,
-                price_open=1.1300,
-                sl=1.1200,
-                tp=1.1400,
-                price_current=1.1301,
-                price_stoplimit=0.0,
-                symbol="EURUSD",
-                comment="",
-                external_id="",
-            ),
-        ]
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_orders_get.return_value = mock_orders
-
-        client.initialize()
-        df_result = client.history_orders_get_as_df(
-            datetime(2022, 1, 1, tzinfo=UTC),
-            datetime(2022, 1, 2, tzinfo=UTC),
-            group="*USD*",
-        )
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert df_result.iloc[0]["symbol"] == "EURUSD"
 
     def test_history_orders_get_empty(self, mock_mt5_import: ModuleType | None) -> None:
         """Test history_orders_get method with empty result."""
@@ -2032,10 +2025,22 @@ class TestMt5DataClientRetryLogic:
         ):
             client._validate_history_input(**kwargs)  # type: ignore[reportPrivateUsage]
 
-    def test_history_deals_get_ticket_only(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        ("call_kwargs", "assert_index", "assert_col"),
+        [
+            ({"ticket": 123456, "index_keys": "ticket"}, 123456, None),
+            ({"position": 345678}, None, ("position_id", 345678)),
+        ],
+        ids=["ticket", "position"],
+    )
+    def test_history_deals_get_filter(
+        self,
+        mock_mt5_import: ModuleType | None,
+        call_kwargs: dict[str, Any],
+        assert_index: int | None,
+        assert_col: tuple[str, Any] | None,
     ) -> None:
-        """Test history_deals_get method with only ticket parameter."""
+        """Test history_deals_get_as_df with ticket or position filter."""
         assert mock_mt5_import is not None
         mock_deals = [
             MockDeal(
@@ -2059,56 +2064,20 @@ class TestMt5DataClientRetryLogic:
                 external_id="",
             ),
         ]
-
         client = Mt5DataClient(mt5=mock_mt5_import)
         mock_mt5_import.initialize.return_value = True
         mock_mt5_import.history_deals_get.return_value = mock_deals
-
         client.initialize()
-        df_result = client.history_deals_get_as_df(ticket=123456, index_keys="ticket")
+        df_result = client.history_deals_get_as_df(**call_kwargs)
 
         assert isinstance(df_result, pd.DataFrame)
         assert len(df_result) == 1
-        assert df_result.index[0] == 123456
-
-    def test_history_deals_get_position_only(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_deals_get method with only position parameter."""
-        assert mock_mt5_import is not None
-        mock_deals = [
-            MockDeal(
-                ticket=123456,
-                order=789012,
-                time=1640995200,
-                time_msc=1640995200000,
-                type=0,
-                entry=0,
-                magic=0,
-                position_id=345678,
-                reason=0,
-                volume=0.1,
-                price=1.1300,
-                commission=-2.5,
-                swap=0.0,
-                profit=10.0,
-                fee=0.0,
-                symbol="EURUSD",
-                comment="",
-                external_id="",
-            ),
-        ]
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_deals_get.return_value = mock_deals
-
-        client.initialize()
-        df_result = client.history_deals_get_as_df(position=345678)
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert df_result.iloc[0]["position_id"] == 345678
+        if assert_index is not None:
+            assert df_result.index[0] == assert_index
+        else:
+            assert assert_col is not None
+            col, val = assert_col
+            assert df_result.iloc[0][col] == val
 
     def test_context_manager_with_exception(
         self, mock_mt5_import: ModuleType | None
@@ -2315,52 +2284,36 @@ class TestMt5DataClientCoverageMissing:
         assert "deal" in result.columns
         assert "order" in result.columns
 
-    def test_flatten_dict_to_one_level_simple(
-        self, mock_mt5_import: ModuleType
+    @pytest.mark.parametrize(
+        ("input_dict", "kwargs", "expected"),
+        [
+            ({"a": 1, "b": 2, "c": 3}, {}, {"a": 1, "b": 2, "c": 3}),
+            (
+                {"a": 1, "nested": {"x": 10, "y": 20}, "b": 2},
+                {},
+                {"a": 1, "nested_x": 10, "nested_y": 20, "b": 2},
+            ),
+            (
+                {"level1": {"level2": {"level3": "value"}}, "simple": "value2"},
+                {"sep": "_"},
+                {"level1_level2": {"level3": "value"}, "simple": "value2"},
+            ),
+        ],
+        ids=["simple", "nested", "custom_separator"],
+    )
+    def test_flatten_dict_to_one_level(
+        self,
+        mock_mt5_import: ModuleType,
+        input_dict: dict[str, Any],
+        kwargs: dict[str, Any],
+        expected: dict[str, Any],
     ) -> None:
-        """Test _flatten_dict_to_one_level with simple dict."""
+        """Test _flatten_dict_to_one_level with various input structures."""
         client = Mt5DataClient(mt5=mock_mt5_import)
-
-        input_dict = {"a": 1, "b": 2, "c": 3}
         result = client._flatten_dict_to_one_level(  # type: ignore[reportPrivateUsage]
-            input_dict
+            input_dict, **kwargs
         )
-
-        assert result == {"a": 1, "b": 2, "c": 3}
-
-    def test_flatten_dict_to_one_level_nested(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test _flatten_dict_to_one_level with nested dict."""
-        client = Mt5DataClient(mt5=mock_mt5_import)
-
-        input_dict = {
-            "a": 1,
-            "nested": {"x": 10, "y": 20},
-            "b": 2,
-        }
-        result = client._flatten_dict_to_one_level(  # type: ignore[reportPrivateUsage]
-            input_dict
-        )
-
-        assert result == {"a": 1, "nested_x": 10, "nested_y": 20, "b": 2}
-
-    def test_flatten_dict_to_one_level_custom_separator(
-        self, mock_mt5_import: ModuleType
-    ) -> None:
-        """Test _flatten_dict_to_one_level with custom separator."""
-        client = Mt5DataClient(mt5=mock_mt5_import)
-
-        input_dict = {
-            "level1": {"level2": {"level3": "value"}},
-            "simple": "value2",
-        }
-        result = client._flatten_dict_to_one_level(  # type: ignore[reportPrivateUsage]
-            input_dict,
-            sep="_",
-        )
-
-        assert result == {"level1_level2": {"level3": "value"}, "simple": "value2"}
+        assert result == expected
 
     def test_symbols_get_as_dicts(self, mock_mt5_import: ModuleType) -> None:
         """Test symbols_get_as_dicts method."""
@@ -2977,112 +2930,9 @@ class TestMt5DataClientCoverageMissing:
         mock_mt5_import: ModuleType,
     ) -> None:
         """Test detect_and_convert_time decorator with list return value."""
-        # Mock a method that returns a list
-        mock_symbols = [
-            MockSymbolInfo(
-                custom=False,
-                chart_mode=0,
-                select=True,
-                visible=True,
-                session_deals=0,
-                session_buy_orders=0,
-                session_sell_orders=0,
-                volume=0,
-                volumehigh=0,
-                volumelow=0,
-                time=1640995200,
-                digits=5,
-                spread=10,
-                spread_float=True,
-                ticks_bookdepth=10,
-                trade_calc_mode=0,
-                trade_mode=4,
-                start_time=0,
-                expiration_time=0,
-                trade_stops_level=0,
-                trade_freeze_level=0,
-                trade_exemode=1,
-                swap_mode=1,
-                swap_rollover3days=3,
-                margin_hedged_use_leg=False,
-                expiration_mode=7,
-                filling_mode=1,
-                order_mode=127,
-                order_gtc_mode=0,
-                option_mode=0,
-                option_right=0,
-                bid=1.13200,
-                bidhigh=1.13500,
-                bidlow=1.13000,
-                ask=1.13210,
-                askhigh=1.13510,
-                asklow=1.13010,
-                last=1.13205,
-                lasthigh=1.13505,
-                lastlow=1.13005,
-                volume_real=1000000.0,
-                volumehigh_real=2000000.0,
-                volumelow_real=500000.0,
-                option_strike=0.0,
-                point=0.00001,
-                trade_tick_value=1.0,
-                trade_tick_value_profit=1.0,
-                trade_tick_value_loss=1.0,
-                trade_tick_size=0.00001,
-                trade_contract_size=100000.0,
-                trade_accrued_interest=0.0,
-                trade_face_value=0.0,
-                trade_liquidity_rate=0.0,
-                volume_min=0.01,
-                volume_max=500.0,
-                volume_step=0.01,
-                volume_limit=0.0,
-                swap_long=-0.5,
-                swap_short=-0.3,
-                margin_initial=0.0,
-                margin_maintenance=0.0,
-                session_volume=0.0,
-                session_turnover=0.0,
-                session_interest=0.0,
-                session_buy_orders_volume=0.0,
-                session_sell_orders_volume=0.0,
-                session_open=1.13100,
-                session_close=1.13200,
-                session_aw=0.0,
-                session_price_settlement=0.0,
-                session_price_limit_min=0.0,
-                session_price_limit_max=0.0,
-                margin_hedged=50000.0,
-                price_change=0.0010,
-                price_volatility=0.0,
-                price_theoretical=0.0,
-                price_greeks_delta=0.0,
-                price_greeks_theta=0.0,
-                price_greeks_gamma=0.0,
-                price_greeks_vega=0.0,
-                price_greeks_rho=0.0,
-                price_greeks_omega=0.0,
-                price_sensitivity=0.0,
-                basis="",
-                category="",
-                currency_base="EUR",
-                currency_profit="USD",
-                currency_margin="USD",
-                bank="",
-                description="Euro vs US Dollar",
-                exchange="",
-                formula="",
-                isin="",
-                name="EURUSD",
-                page="",
-                path="Forex\\Majors\\EURUSD",
-            )
-        ]
-
-        mock_mt5_import.symbols_get.return_value = mock_symbols
+        mock_mt5_import.symbols_get.return_value = [_MOCK_SYMBOL_INFO]
         client = create_initialized_client(mock_mt5_import)
 
-        # This should trigger the list processing path
         result = client.symbols_get_as_dicts()
         assert isinstance(result, list)
         assert len(result) == 1
@@ -3108,114 +2958,12 @@ class TestMt5DataClientCoverageMissing:
         mock_mt5_import: ModuleType,
     ) -> None:
         """Test detect_and_convert_time decorator with dict return."""
-        # This test specifically targets early return for datetime
-        mock_symbol = MockSymbolInfo(
-            custom=False,
-            chart_mode=0,
-            select=True,
-            visible=True,
-            session_deals=0,
-            session_buy_orders=0,
-            session_sell_orders=0,
-            volume=0,
-            volumehigh=0,
-            volumelow=0,
-            time=1640995200,
-            digits=5,
-            spread=10,
-            spread_float=True,
-            ticks_bookdepth=10,
-            trade_calc_mode=0,
-            trade_mode=4,
-            start_time=0,
-            expiration_time=0,
-            trade_stops_level=0,
-            trade_freeze_level=0,
-            trade_exemode=1,
-            swap_mode=1,
-            swap_rollover3days=3,
-            margin_hedged_use_leg=False,
-            expiration_mode=7,
-            filling_mode=1,
-            order_mode=127,
-            order_gtc_mode=0,
-            option_mode=0,
-            option_right=0,
-            bid=1.13200,
-            bidhigh=1.13500,
-            bidlow=1.13000,
-            ask=1.13210,
-            askhigh=1.13510,
-            asklow=1.13010,
-            last=1.13205,
-            lasthigh=1.13505,
-            lastlow=1.13005,
-            volume_real=1000000.0,
-            volumehigh_real=2000000.0,
-            volumelow_real=500000.0,
-            option_strike=0.0,
-            point=0.00001,
-            trade_tick_value=1.0,
-            trade_tick_value_profit=1.0,
-            trade_tick_value_loss=1.0,
-            trade_tick_size=0.00001,
-            trade_contract_size=100000.0,
-            trade_accrued_interest=0.0,
-            trade_face_value=0.0,
-            trade_liquidity_rate=0.0,
-            volume_min=0.01,
-            volume_max=500.0,
-            volume_step=0.01,
-            volume_limit=0.0,
-            swap_long=-0.5,
-            swap_short=-0.3,
-            margin_initial=0.0,
-            margin_maintenance=0.0,
-            session_volume=0.0,
-            session_turnover=0.0,
-            session_interest=0.0,
-            session_buy_orders_volume=0.0,
-            session_sell_orders_volume=0.0,
-            session_open=1.13100,
-            session_close=1.13200,
-            session_aw=0.0,
-            session_price_settlement=0.0,
-            session_price_limit_min=0.0,
-            session_price_limit_max=0.0,
-            margin_hedged=50000.0,
-            price_change=0.0010,
-            price_volatility=0.0,
-            price_theoretical=0.0,
-            price_greeks_delta=0.0,
-            price_greeks_theta=0.0,
-            price_greeks_gamma=0.0,
-            price_greeks_vega=0.0,
-            price_greeks_rho=0.0,
-            price_greeks_omega=0.0,
-            price_sensitivity=0.0,
-            basis="",
-            category="",
-            currency_base="EUR",
-            currency_profit="USD",
-            currency_margin="USD",
-            bank="",
-            description="Euro vs US Dollar",
-            exchange="",
-            formula="",
-            isin="",
-            name="EURUSD",
-            page="",
-            path="Forex\\Majors\\EURUSD",
-        )
-
-        mock_mt5_import.symbol_info.return_value = mock_symbol
+        mock_mt5_import.symbol_info.return_value = _MOCK_SYMBOL_INFO
         client = create_initialized_client(mock_mt5_import)
 
-        # This should trigger return _convert_time_values_in_dict()
         result = client.symbol_info_as_dict("EURUSD", skip_to_datetime=False)
         assert isinstance(result, dict)
         assert "time" in result
-        # Check that time was converted to datetime
         assert isinstance(result["time"], pd.Timestamp)
 
     def test_convert_time_decorator_list_with_dicts_convert_time_true(
@@ -3223,118 +2971,14 @@ class TestMt5DataClientCoverageMissing:
         mock_mt5_import: ModuleType,
     ) -> None:
         """Test detect_and_convert_time decorator with list of dicts."""
-        # This test specifically targets dict processing
-        mock_symbols = [
-            MockSymbolInfo(
-                custom=False,
-                chart_mode=0,
-                select=True,
-                visible=True,
-                session_deals=0,
-                session_buy_orders=0,
-                session_sell_orders=0,
-                volume=0,
-                volumehigh=0,
-                volumelow=0,
-                time=1640995200,
-                digits=5,
-                spread=10,
-                spread_float=True,
-                ticks_bookdepth=10,
-                trade_calc_mode=0,
-                trade_mode=4,
-                start_time=0,
-                expiration_time=0,
-                trade_stops_level=0,
-                trade_freeze_level=0,
-                trade_exemode=1,
-                swap_mode=1,
-                swap_rollover3days=3,
-                margin_hedged_use_leg=False,
-                expiration_mode=7,
-                filling_mode=1,
-                order_mode=127,
-                order_gtc_mode=0,
-                option_mode=0,
-                option_right=0,
-                bid=1.13200,
-                bidhigh=1.13500,
-                bidlow=1.13000,
-                ask=1.13210,
-                askhigh=1.13510,
-                asklow=1.13010,
-                last=1.13205,
-                lasthigh=1.13505,
-                lastlow=1.13005,
-                volume_real=1000000.0,
-                volumehigh_real=2000000.0,
-                volumelow_real=500000.0,
-                option_strike=0.0,
-                point=0.00001,
-                trade_tick_value=1.0,
-                trade_tick_value_profit=1.0,
-                trade_tick_value_loss=1.0,
-                trade_tick_size=0.00001,
-                trade_contract_size=100000.0,
-                trade_accrued_interest=0.0,
-                trade_face_value=0.0,
-                trade_liquidity_rate=0.0,
-                volume_min=0.01,
-                volume_max=500.0,
-                volume_step=0.01,
-                volume_limit=0.0,
-                swap_long=-0.5,
-                swap_short=-0.3,
-                margin_initial=0.0,
-                margin_maintenance=0.0,
-                session_volume=0.0,
-                session_turnover=0.0,
-                session_interest=0.0,
-                session_buy_orders_volume=0.0,
-                session_sell_orders_volume=0.0,
-                session_open=1.13100,
-                session_close=1.13200,
-                session_aw=0.0,
-                session_price_settlement=0.0,
-                session_price_limit_min=0.0,
-                session_price_limit_max=0.0,
-                margin_hedged=50000.0,
-                price_change=0.0010,
-                price_volatility=0.0,
-                price_theoretical=0.0,
-                price_greeks_delta=0.0,
-                price_greeks_theta=0.0,
-                price_greeks_gamma=0.0,
-                price_greeks_vega=0.0,
-                price_greeks_rho=0.0,
-                price_greeks_omega=0.0,
-                price_sensitivity=0.0,
-                basis="",
-                category="",
-                currency_base="EUR",
-                currency_profit="USD",
-                currency_margin="USD",
-                bank="",
-                description="Euro vs US Dollar",
-                exchange="",
-                formula="",
-                isin="",
-                name="EURUSD",
-                page="",
-                path="Forex\\Majors\\EURUSD",
-            )
-        ]
-
-        mock_mt5_import.symbols_get.return_value = mock_symbols
+        mock_mt5_import.symbols_get.return_value = [_MOCK_SYMBOL_INFO]
         client = create_initialized_client(mock_mt5_import)
 
-        # This should trigger the list comprehension with dict processing
         result = client.symbols_get_as_dicts(skip_to_datetime=False)
         assert isinstance(result, list)
         assert len(result) == 1
         assert isinstance(result[0], dict)
         assert "time" in result[0]
-        # Check that time was converted to datetime
         assert isinstance(result[0]["time"], pd.Timestamp)
 
     def test_convert_time_decorator_non_standard_return_type(

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -951,30 +951,53 @@ class TestMt5DataClient:
         assert result == pytest.approx(10.0)
 
     @pytest.mark.parametrize(
-        "args",
+        ("args", "last_error", "context_substr"),
         [
-            (0, "EURUSD", 0.0, 1.1300, 1.1400),
-            (0, "EURUSD", 0.1, 0.0, 1.1400),
-            (0, "EURUSD", 0.1, 1.1300, 0.0),
-            (0, "EURUSD", 0.1, 1.1300, 1.1400),
+            pytest.param(
+                (0, "EURUSD", 0.0, 1.1300, 1.1400),
+                (1, "Invalid volume"),
+                "volume=0.0",
+                id="invalid-volume",
+            ),
+            pytest.param(
+                (0, "EURUSD", 0.1, 0.0, 1.1400),
+                (1, "Invalid price_open"),
+                "price_open=0.0",
+                id="invalid-price-open",
+            ),
+            pytest.param(
+                (0, "EURUSD", 0.1, 1.1300, 0.0),
+                (1, "Invalid price_close"),
+                "price_close=0.0",
+                id="invalid-price-close",
+            ),
+            pytest.param(
+                (0, "EURUSD", 0.1, 1.1300, 1.1400),
+                (1, "Order calc profit failed"),
+                "Order calc profit failed",
+                id="mt5-error",
+            ),
         ],
     )
     def test_order_calc_profit_returns_none(
         self,
         mock_mt5_import: ModuleType | None,
         args: tuple[int, str, float, float, float],
+        last_error: tuple[int, str],
+        context_substr: str,
     ) -> None:
-        """Test order_calc_profit raises when MT5 returns None."""
+        """Test order_calc_profit raises Mt5RuntimeError with per-case context."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
         mock_mt5_import.order_calc_profit.return_value = None
-        mock_mt5_import.last_error.return_value = (1, "error")
+        mock_mt5_import.last_error.return_value = last_error
 
         client = create_initialized_client(mock_mt5_import)
         with pytest.raises(
             Mt5RuntimeError, match=r"MT5 order_calc_profit returned None"
-        ):
+        ) as exc_info:
             client.order_calc_profit(*args)
+        assert context_substr in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "return_value",
@@ -2030,8 +2053,26 @@ class TestMt5DataClientRetryLogic:
         [
             ({"ticket": 123456, "index_keys": "ticket"}, 123456, None),
             ({"position": 345678}, None, ("position_id", 345678)),
+            (
+                {
+                    "date_from": datetime(2022, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2022, 1, 2, tzinfo=UTC),
+                    "symbol": "EURUSD",
+                },
+                None,
+                ("symbol", "EURUSD"),
+            ),
+            (
+                {
+                    "date_from": datetime(2022, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2022, 1, 2, tzinfo=UTC),
+                    "group": "*USD*",
+                },
+                None,
+                ("symbol", "EURUSD"),
+            ),
         ],
-        ids=["ticket", "position"],
+        ids=["ticket", "position", "symbol", "group"],
     )
     def test_history_deals_get_filter(
         self,

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -243,11 +243,27 @@ class TestMt5Client:
         assert result is mock_result
         getattr(mock_mt5, method_name).assert_called_once_with("EURUSD")
 
-    def test_symbol_select(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
-        """Test symbol_select method."""
+    @pytest.mark.parametrize(
+        "enable", [True, False], ids=["enable-true", "enable-false"]
+    )
+    def test_symbol_select(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, enable: bool
+    ) -> None:
+        """Test symbol_select with explicit enable flag."""
         mock_mt5.symbol_select.return_value = True
 
-        result = initialized_client.symbol_select("EURUSD", True)  # noqa: FBT003
+        result = initialized_client.symbol_select("EURUSD", enable)
+
+        assert result is True
+        mock_mt5.symbol_select.assert_called_once_with("EURUSD", enable)
+
+    def test_symbol_select_default(
+        self, initialized_client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test symbol_select defaults to enable=True."""
+        mock_mt5.symbol_select.return_value = True
+
+        result = initialized_client.symbol_select("EURUSD")
 
         assert result is True
         mock_mt5.symbol_select.assert_called_once_with("EURUSD", True)  # noqa: FBT003
@@ -506,6 +522,7 @@ class TestMt5Client:
             ("symbols_total", [], 0),
             ("orders_total", [], 0),
             ("positions_total", [], 0),
+            ("symbols_get", [], None),
             ("symbol_info", ["EURUSD"], None),
             ("account_info", [], None),
             ("terminal_info", [], None),
@@ -514,6 +531,7 @@ class TestMt5Client:
             "symbols_total",
             "orders_total",
             "positions_total",
+            "symbols_get",
             "symbol_info",
             "account_info",
             "terminal_info",

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -225,35 +225,22 @@ class TestMt5Client:
 
         assert "MT5 symbols_get returned None" in str(exc_info.value)
 
-    def test_symbol_info(
+    @pytest.mark.parametrize("method_name", ["symbol_info", "symbol_info_tick"])
+    def test_symbol_info_methods(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test symbol_info method."""
-        mock_info = mocker.MagicMock()
-        mock_mt5.symbol_info.return_value = mock_info
+        """Test symbol_info and symbol_info_tick methods."""
+        mock_result = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = mock_result
 
-        result = initialized_client.symbol_info("EURUSD")
+        result = getattr(initialized_client, method_name)("EURUSD")
 
-        assert result is mock_info
-        mock_mt5.symbol_info.assert_called_once_with("EURUSD")
-
-    def test_symbol_info_tick(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test symbol_info_tick method."""
-        mock_tick = mocker.MagicMock()
-        mock_mt5.symbol_info_tick.return_value = mock_tick
-
-        result = initialized_client.symbol_info_tick("EURUSD")
-
-        assert result is mock_tick
-        mock_mt5.symbol_info_tick.assert_called_once_with("EURUSD")
+        assert result is mock_result
+        getattr(mock_mt5, method_name).assert_called_once_with("EURUSD")
 
     def test_symbol_select(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
         """Test symbol_select method."""
@@ -292,99 +279,48 @@ class TestMt5Client:
         assert len(result) == 1
         mock_mt5.market_book_get.assert_called_once_with("EURUSD")
 
-    def test_copy_rates_from(
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("copy_rates_from", ("EURUSD", 1, datetime(2023, 1, 1, tzinfo=UTC), 100)),
+            ("copy_rates_from_pos", ("EURUSD", 1, 0, 100)),
+            (
+                "copy_rates_range",
+                (
+                    "EURUSD",
+                    1,
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                ),
+            ),
+            ("copy_ticks_from", ("EURUSD", datetime(2023, 1, 1, tzinfo=UTC), 1000, 0)),
+            (
+                "copy_ticks_range",
+                (
+                    "EURUSD",
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                    0,
+                ),
+            ),
+        ],
+    )
+    def test_copy_methods(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
+        args: tuple[Any, ...],
     ) -> None:
-        """Test copy_rates_from method."""
-        now = datetime.now(UTC)
-        mock_rates = mocker.MagicMock()
-        mock_mt5.copy_rates_from.return_value = mock_rates
+        """Test copy_rates and copy_ticks methods."""
+        mock_result = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = mock_result
 
-        result = initialized_client.copy_rates_from("EURUSD", 1, now, 100)
+        result = getattr(initialized_client, method_name)(*args)
 
-        assert result is mock_rates
-        mock_mt5.copy_rates_from.assert_called_once_with("EURUSD", 1, now, 100)
-
-    def test_copy_rates_from_pos(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test copy_rates_from_pos method."""
-        mock_rates = mocker.MagicMock()
-        mock_mt5.copy_rates_from_pos.return_value = mock_rates
-
-        result = initialized_client.copy_rates_from_pos("EURUSD", 1, 0, 100)
-
-        assert result is mock_rates
-        mock_mt5.copy_rates_from_pos.assert_called_once_with("EURUSD", 1, 0, 100)
-
-    def test_copy_rates_range(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test copy_rates_range method."""
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_rates = mocker.MagicMock()
-        mock_mt5.copy_rates_range.return_value = mock_rates
-
-        result = initialized_client.copy_rates_range("EURUSD", 1, date_from, date_to)
-
-        assert result is mock_rates
-        mock_mt5.copy_rates_range.assert_called_once_with(
-            "EURUSD", 1, date_from, date_to
-        )
-
-    def test_copy_ticks_from(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test copy_ticks_from method."""
-        now = datetime.now(UTC)
-        mock_ticks = mocker.MagicMock()
-        mock_mt5.copy_ticks_from.return_value = mock_ticks
-
-        result = initialized_client.copy_ticks_from("EURUSD", now, 1000, 0)
-
-        assert result is mock_ticks
-        mock_mt5.copy_ticks_from.assert_called_once_with("EURUSD", now, 1000, 0)
-
-    def test_copy_ticks_range(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test copy_ticks_range method."""
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_ticks = mocker.MagicMock()
-        mock_mt5.copy_ticks_range.return_value = mock_ticks
-
-        result = initialized_client.copy_ticks_range("EURUSD", date_from, date_to, 0)
-
-        assert result is mock_ticks
-        mock_mt5.copy_ticks_range.assert_called_once_with(
-            "EURUSD", date_from, date_to, 0
-        )
-
-    def test_orders_total(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
-        """Test orders_total method."""
-        mock_mt5.orders_total.return_value = 5
-
-        result = initialized_client.orders_total()
-
-        assert result == 5
-        mock_mt5.orders_total.assert_called_once()
+        assert result is mock_result
+        getattr(mock_mt5, method_name).assert_called_once_with(*args)
 
     def test_orders_get(
         self,
@@ -402,72 +338,46 @@ class TestMt5Client:
         assert len(result) == 1
         mock_mt5.orders_get.assert_called_once_with(symbol="EURUSD")
 
-    def test_order_calc_margin(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected"),
+        [
+            ("order_calc_margin", (0, "EURUSD", 1.0, 1.1234), 1000.0),
+            ("order_calc_profit", (0, "EURUSD", 1.0, 1.1234, 1.1334), 100.0),
+        ],
+    )
+    def test_calc_methods(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        args: tuple[Any, ...],
+        expected: float,
     ) -> None:
-        """Test order_calc_margin method."""
-        mock_mt5.order_calc_margin.return_value = 1000.0
+        """Test order_calc_margin and order_calc_profit methods."""
+        getattr(mock_mt5, method_name).return_value = expected
 
-        result = initialized_client.order_calc_margin(0, "EURUSD", 1.0, 1.1234)
+        result = getattr(initialized_client, method_name)(*args)
 
-        assert result == pytest.approx(1000.0)
-        mock_mt5.order_calc_margin.assert_called_once_with(0, "EURUSD", 1.0, 1.1234)
+        assert result == pytest.approx(expected)
+        getattr(mock_mt5, method_name).assert_called_once_with(*args)
 
-    def test_order_calc_profit(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test order_calc_profit method."""
-        mock_mt5.order_calc_profit.return_value = 100.0
-
-        result = initialized_client.order_calc_profit(0, "EURUSD", 1.0, 1.1234, 1.1334)
-
-        assert result == pytest.approx(100.0)
-        mock_mt5.order_calc_profit.assert_called_once_with(
-            0, "EURUSD", 1.0, 1.1234, 1.1334
-        )
-
-    def test_order_check(
+    @pytest.mark.parametrize("method_name", ["order_check", "order_send"])
+    def test_order_request_methods(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test order_check method."""
+        """Test order_check and order_send methods."""
         request = {"action": 1, "symbol": "EURUSD", "volume": 0.1}
         mock_result = mocker.MagicMock()
-        mock_mt5.order_check.return_value = mock_result
+        getattr(mock_mt5, method_name).return_value = mock_result
 
-        result = initialized_client.order_check(request)
-
-        assert result is mock_result
-        mock_mt5.order_check.assert_called_once_with(request)
-
-    def test_order_send(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test order_send method."""
-        request = {"action": 1, "symbol": "EURUSD", "volume": 0.1}
-        mock_result = mocker.MagicMock()
-        mock_mt5.order_send.return_value = mock_result
-
-        result = initialized_client.order_send(request)
+        result = getattr(initialized_client, method_name)(request)
 
         assert result is mock_result
-        mock_mt5.order_send.assert_called_once_with(request)
-
-    def test_positions_total(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test positions_total method."""
-        mock_mt5.positions_total.return_value = 3
-
-        result = initialized_client.positions_total()
-
-        assert result == 3
-        mock_mt5.positions_total.assert_called_once()
+        getattr(mock_mt5, method_name).assert_called_once_with(request)
 
     def test_positions_get(
         self,
@@ -485,82 +395,91 @@ class TestMt5Client:
         assert len(result) == 1
         mock_mt5.positions_get.assert_called_once_with(symbol="EURUSD")
 
-    def test_account_info(
+    @pytest.mark.parametrize("method_name", ["account_info", "terminal_info"])
+    def test_info_methods(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test account_info method."""
-        mock_info = mocker.MagicMock()
-        mock_mt5.account_info.return_value = mock_info
+        """Test account_info and terminal_info methods."""
+        mock_result = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = mock_result
 
-        result = initialized_client.account_info()
+        result = getattr(initialized_client, method_name)()
 
-        assert result is mock_info
-        mock_mt5.account_info.assert_called_once()
+        assert result is mock_result
+        getattr(mock_mt5, method_name).assert_called_once()
 
-    def test_terminal_info(
+    @pytest.mark.parametrize(
+        ("method_name", "expected"),
+        [
+            ("history_orders_total", 10),
+            ("history_deals_total", 20),
+        ],
+    )
+    def test_history_totals(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
-        mocker: MockerFixture,
+        method_name: str,
+        expected: int,
     ) -> None:
-        """Test terminal_info method."""
-        mock_info = mocker.MagicMock()
-        mock_mt5.terminal_info.return_value = mock_info
-
-        result = initialized_client.terminal_info()
-
-        assert result is mock_info
-        mock_mt5.terminal_info.assert_called_once()
-
-    def test_history_orders_total(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test history_orders_total method."""
+        """Test history_orders_total and history_deals_total methods."""
         date_from = datetime(2023, 1, 1, tzinfo=UTC)
         date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_mt5.history_orders_total.return_value = 10
+        getattr(mock_mt5, method_name).return_value = expected
 
-        result = initialized_client.history_orders_total(date_from, date_to)
+        result = getattr(initialized_client, method_name)(date_from, date_to)
 
-        assert result == 10
-        mock_mt5.history_orders_total.assert_called_once_with(date_from, date_to)
+        assert result == expected
+        getattr(mock_mt5, method_name).assert_called_once_with(date_from, date_to)
 
-    def test_history_orders_get_by_date(
+    @pytest.mark.parametrize("method_name", ["history_orders_get", "history_deals_get"])
+    def test_history_get_by_date(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test history_orders_get with date range."""
+        """Test history_orders_get and history_deals_get with date range."""
         date_from = datetime(2023, 1, 1, tzinfo=UTC)
         date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_order = mocker.MagicMock()
-        mock_mt5.history_orders_get.return_value = (mock_order,)
+        mock_item = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = (mock_item,)
 
-        result = initialized_client.history_orders_get(date_from, date_to)
+        result = getattr(initialized_client, method_name)(date_from, date_to)
 
         assert result is not None
         assert len(result) == 1
-        mock_mt5.history_orders_get.assert_called_once_with(date_from, date_to)
+        getattr(mock_mt5, method_name).assert_called_once_with(date_from, date_to)
 
-    def test_history_orders_get_by_ticket(
+    @pytest.mark.parametrize(
+        ("method_name", "kwargs"),
+        [
+            ("history_orders_get", {"ticket": 12345}),
+            ("history_deals_get", {"position": 54321}),
+        ],
+    )
+    def test_history_get_by_id(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
+        kwargs: dict[str, int],
     ) -> None:
-        """Test history_orders_get by ticket."""
-        mock_order = mocker.MagicMock()
-        mock_mt5.history_orders_get.return_value = (mock_order,)
+        """Test history_orders_get by ticket and history_deals_get by position."""
+        mock_item = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = (mock_item,)
 
-        result = initialized_client.history_orders_get(ticket=12345)
+        result = getattr(initialized_client, method_name)(**kwargs)
 
         assert result is not None
         assert len(result) == 1
-        mock_mt5.history_orders_get.assert_called_once_with(ticket=12345)
+        getattr(mock_mt5, method_name).assert_called_once_with(**kwargs)
 
     def test_history_orders_get_missing_dates(
         self, initialized_client: Mt5Client, mock_mt5: Mock
@@ -571,53 +490,6 @@ class TestMt5Client:
         result = initialized_client.history_orders_get()
         assert result == ()
         mock_mt5.history_orders_get.assert_called_once_with(None, None)
-
-    def test_history_deals_total(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test history_deals_total method."""
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_mt5.history_deals_total.return_value = 20
-
-        result = initialized_client.history_deals_total(date_from, date_to)
-
-        assert result == 20
-        mock_mt5.history_deals_total.assert_called_once_with(date_from, date_to)
-
-    def test_history_deals_get_by_date(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test history_deals_get with date range."""
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        mock_deal = mocker.MagicMock()
-        mock_mt5.history_deals_get.return_value = (mock_deal,)
-
-        result = initialized_client.history_deals_get(date_from, date_to)
-
-        assert result is not None
-        assert len(result) == 1
-        mock_mt5.history_deals_get.assert_called_once_with(date_from, date_to)
-
-    def test_history_deals_get_by_position(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test history_deals_get by position."""
-        mock_deal = mocker.MagicMock()
-        mock_mt5.history_deals_get.return_value = (mock_deal,)
-
-        result = initialized_client.history_deals_get(position=54321)
-
-        assert result is not None
-        assert len(result) == 1
-        mock_mt5.history_deals_get.assert_called_once_with(position=54321)
 
     def test_method_not_initialized(self, client: Mt5Client) -> None:
         """Test calling methods when not initialized."""
@@ -677,182 +549,139 @@ class TestMt5Client:
 
         mock_mt5.shutdown.assert_called_once()
 
-    def test_error_handling_methods(
+    @pytest.mark.parametrize("method_name", ["account_info", "terminal_info"])
+    def test_info_methods_raise_on_none(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
+    ) -> None:
+        """Test that info methods raise Mt5RuntimeError when MT5 returns None."""
+        getattr(mock_mt5, method_name).return_value = None
+        with pytest.raises(Mt5RuntimeError):
+            getattr(initialized_client, method_name)()
+
+    @pytest.mark.parametrize(
+        "method_name", ["symbols_total", "orders_total", "positions_total"]
+    )
+    def test_total_methods_pass_through_none(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
+    ) -> None:
+        """Test that total methods pass through None without raising."""
+        getattr(mock_mt5, method_name).return_value = None
+        assert getattr(initialized_client, method_name)() is None
+
+    @pytest.mark.parametrize(
+        "method_name", ["history_orders_total", "history_deals_total"]
+    )
+    def test_history_total_methods_pass_through_none(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
+    ) -> None:
+        """Test that history total methods pass through None without raising."""
+        date_from = datetime(2023, 1, 1, tzinfo=UTC)
+        date_to = datetime(2023, 1, 31, tzinfo=UTC)
+        getattr(mock_mt5, method_name).return_value = None
+        assert getattr(initialized_client, method_name)(date_from, date_to) is None
+
+    @pytest.mark.parametrize("method_name", ["market_book_add", "market_book_release"])
+    def test_market_book_add_release_pass_through_false(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
+    ) -> None:
+        """Test that market_book_add/release return False without raising."""
+        getattr(mock_mt5, method_name).return_value = False
+        assert getattr(initialized_client, method_name)("EURUSD") is False
+
+    def test_market_book_get_raises_on_none(
         self, initialized_client: Mt5Client, mock_mt5: Mock
     ) -> None:
-        """Test error handling for methods that return None."""
-        # Test methods that handle None return values with validation
-        mock_mt5.account_info.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.account_info()
-
-        mock_mt5.terminal_info.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.terminal_info()
-
-        # These methods now return None directly without raising errors
-        mock_mt5.symbols_total.return_value = None
-        result = initialized_client.symbols_total()
-        assert result is None
-
-        mock_mt5.orders_total.return_value = None
-        result = initialized_client.orders_total()
-        assert result is None
-
-        mock_mt5.positions_total.return_value = None
-        result = initialized_client.positions_total()
-        assert result is None
-
-        mock_mt5.history_orders_total.return_value = None
-        result = initialized_client.history_orders_total(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-        )
-        assert result is None
-
-        mock_mt5.history_deals_total.return_value = None
-        result = initialized_client.history_deals_total(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-        )
-        assert result is None
-
-    def test_market_book_failures(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test market book method failures."""
-        mock_mt5.market_book_add.return_value = False
-        result = initialized_client.market_book_add("EURUSD")
-        assert result is False
-
-        mock_mt5.market_book_release.return_value = False
-        result = initialized_client.market_book_release("EURUSD")
-        assert result is False
-
+        """Test that market_book_get raises Mt5RuntimeError on None."""
         mock_mt5.market_book_get.return_value = None
         with pytest.raises(Mt5RuntimeError):
             initialized_client.market_book_get("EURUSD")
 
-    def test_calculation_methods_failures(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("order_calc_margin", (0, "EURUSD", 1.0, 1.1234)),
+            ("order_calc_profit", (0, "EURUSD", 1.0, 1.1234, 1.1334)),
+            ("order_check", ({"action": 1, "symbol": "EURUSD", "volume": 0.1},)),
+            ("order_send", ({"action": 1, "symbol": "EURUSD", "volume": 0.1},)),
+        ],
+    )
+    def test_calc_and_trading_methods_raise_on_none(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        args: tuple[Any, ...],
     ) -> None:
-        """Test calculation method failures."""
-        mock_mt5.order_calc_margin.return_value = None
+        """Test that calc and trading methods raise Mt5RuntimeError on None."""
+        getattr(mock_mt5, method_name).return_value = None
         with pytest.raises(Mt5RuntimeError):
-            initialized_client.order_calc_margin(0, "EURUSD", 1.0, 1.1234)
+            getattr(initialized_client, method_name)(*args)
 
-        mock_mt5.order_calc_profit.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.order_calc_profit(0, "EURUSD", 1.0, 1.1234, 1.1334)
-
-    def test_trading_methods_failures(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("copy_rates_from", ("EURUSD", 1, datetime(2023, 1, 1, tzinfo=UTC), 100)),
+            ("copy_rates_from_pos", ("EURUSD", 1, 0, 100)),
+            (
+                "copy_rates_range",
+                (
+                    "EURUSD",
+                    1,
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                ),
+            ),
+            ("copy_ticks_from", ("EURUSD", datetime(2023, 1, 1, tzinfo=UTC), 1000, 0)),
+            (
+                "copy_ticks_range",
+                (
+                    "EURUSD",
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                    0,
+                ),
+            ),
+        ],
+    )
+    def test_copy_methods_raise_on_none(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        args: tuple[Any, ...],
     ) -> None:
-        """Test trading method failures."""
-        mock_mt5.order_check.return_value = None
+        """Test that copy data methods raise Mt5RuntimeError on None."""
+        getattr(mock_mt5, method_name).return_value = None
         with pytest.raises(Mt5RuntimeError):
-            initialized_client.order_check({
-                "action": 1,
-                "symbol": "EURUSD",
-                "volume": 0.1,
-            })
+            getattr(initialized_client, method_name)(*args)
 
-        mock_mt5.order_send.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.order_send({
-                "action": 1,
-                "symbol": "EURUSD",
-                "volume": 0.1,
-            })
-
-    def test_data_methods_failures(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize("method_name", ["orders_get", "positions_get"])
+    def test_get_methods_empty_results(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
     ) -> None:
-        """Test data method failures."""
-        mock_mt5.copy_rates_from.return_value = None
+        """Test get methods raise on None and return empty tuple on empty result."""
+        getattr(mock_mt5, method_name).return_value = None
         with pytest.raises(Mt5RuntimeError):
-            initialized_client.copy_rates_from("EURUSD", 1, datetime.now(UTC), 100)
+            getattr(initialized_client, method_name)()
 
-        mock_mt5.copy_rates_from_pos.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.copy_rates_from_pos("EURUSD", 1, 0, 100)
-
-        mock_mt5.copy_rates_range.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.copy_rates_range(
-                "EURUSD",
-                1,
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 31, tzinfo=UTC),
-            )
-
-        mock_mt5.copy_ticks_from.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.copy_ticks_from("EURUSD", datetime.now(UTC), 1000, 0)
-
-        mock_mt5.copy_ticks_range.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.copy_ticks_range(
-                "EURUSD",
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 31, tzinfo=UTC),
-                0,
-            )
-
-    def test_orders_get_empty_results(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test orders_get with empty results."""
-        mock_mt5.orders_get.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.orders_get()
-
-        mock_mt5.orders_get.return_value = ()
-        result = initialized_client.orders_get()
+        getattr(mock_mt5, method_name).return_value = ()
+        result = getattr(initialized_client, method_name)()
         assert result == ()
 
-    def test_positions_get_empty_results(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize("method_name", ["history_orders_get", "history_deals_get"])
+    def test_history_get_methods_empty_results(
+        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
     ) -> None:
-        """Test positions_get with empty results."""
-        mock_mt5.positions_get.return_value = None
+        """Test history get methods raise on None and return empty tuple otherwise."""
+        date_from = datetime(2023, 1, 1, tzinfo=UTC)
+        date_to = datetime(2023, 1, 31, tzinfo=UTC)
+
+        getattr(mock_mt5, method_name).return_value = None
         with pytest.raises(Mt5RuntimeError):
-            initialized_client.positions_get()
+            getattr(initialized_client, method_name)(date_from, date_to)
 
-        mock_mt5.positions_get.return_value = ()
-        result = initialized_client.positions_get()
-        assert result == ()
-
-    def test_history_methods_empty_results(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test history methods with empty results."""
-        mock_mt5.history_orders_get.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.history_orders_get(
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 31, tzinfo=UTC),
-            )
-
-        mock_mt5.history_orders_get.return_value = ()
-        result = initialized_client.history_orders_get(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-        )
-        assert result == ()
-
-        mock_mt5.history_deals_get.return_value = None
-        with pytest.raises(Mt5RuntimeError):
-            initialized_client.history_deals_get(
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 31, tzinfo=UTC),
-            )
-
-        mock_mt5.history_deals_get.return_value = ()
-        result = initialized_client.history_deals_get(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-        )
+        getattr(mock_mt5, method_name).return_value = ()
+        result = getattr(initialized_client, method_name)(date_from, date_to)
         assert result == ()
 
     def test_symbol_select_failure(
@@ -863,93 +692,49 @@ class TestMt5Client:
         with pytest.raises(Mt5RuntimeError):
             initialized_client.symbol_select("EURUSD")
 
-    def test_history_orders_get_with_group(
+    @pytest.mark.parametrize("method_name", ["history_orders_get", "history_deals_get"])
+    def test_history_get_with_group(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test history_orders_get with group parameter."""
-        mock_order = mocker.MagicMock()
-        mock_mt5.history_orders_get.return_value = (mock_order,)
+        """Test history_orders_get and history_deals_get with group parameter."""
+        date_from = datetime(2023, 1, 1, tzinfo=UTC)
+        date_to = datetime(2023, 1, 31, tzinfo=UTC)
+        mock_item = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = (mock_item,)
 
-        result = initialized_client.history_orders_get(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-            group="*USD*",
+        result = getattr(initialized_client, method_name)(
+            date_from, date_to, group="*USD*"
         )
 
         assert result is not None
         assert len(result) == 1
-        mock_mt5.history_orders_get.assert_called_once_with(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-            group="*USD*",
+        getattr(mock_mt5, method_name).assert_called_once_with(
+            date_from, date_to, group="*USD*"
         )
 
-    def test_history_deals_get_with_group(
+    @pytest.mark.parametrize("method_name", ["orders_get", "positions_get"])
+    def test_get_methods_with_parameters(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
+        method_name: str,
     ) -> None:
-        """Test history_deals_get with group parameter."""
-        mock_deal = mocker.MagicMock()
-        mock_mt5.history_deals_get.return_value = (mock_deal,)
+        """Test orders_get and positions_get with different parameter combinations."""
+        mock_item = mocker.MagicMock()
+        getattr(mock_mt5, method_name).return_value = (mock_item,)
 
-        result = initialized_client.history_deals_get(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-            group="*USD*",
-        )
-
+        result = getattr(initialized_client, method_name)(group="*USD*")
         assert result is not None
-        assert len(result) == 1
-        mock_mt5.history_deals_get.assert_called_once_with(
-            datetime(2023, 1, 1, tzinfo=UTC),
-            datetime(2023, 1, 31, tzinfo=UTC),
-            group="*USD*",
-        )
+        getattr(mock_mt5, method_name).assert_called_with(group="*USD*")
 
-    def test_orders_get_with_parameters(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test orders_get with different parameter combinations."""
-        mock_order = mocker.MagicMock()
-        mock_mt5.orders_get.return_value = (mock_order,)
-
-        # Test with group parameter
-        result = initialized_client.orders_get(group="*USD*")
+        result = getattr(initialized_client, method_name)(ticket=12345)
         assert result is not None
-        mock_mt5.orders_get.assert_called_with(group="*USD*")
-
-        # Test with ticket parameter
-        result = initialized_client.orders_get(ticket=12345)
-        assert result is not None
-        mock_mt5.orders_get.assert_called_with(ticket=12345)
-
-    def test_positions_get_with_parameters(
-        self,
-        initialized_client: Mt5Client,
-        mock_mt5: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test positions_get with different parameter combinations."""
-        mock_position = mocker.MagicMock()
-        mock_mt5.positions_get.return_value = (mock_position,)
-
-        # Test with group parameter
-        result = initialized_client.positions_get(group="*USD*")
-        assert result is not None
-        mock_mt5.positions_get.assert_called_with(group="*USD*")
-
-        # Test with ticket parameter
-        result = initialized_client.positions_get(ticket=12345)
-        assert result is not None
-        mock_mt5.positions_get.assert_called_with(ticket=12345)
+        getattr(mock_mt5, method_name).assert_called_with(ticket=12345)
 
     def test_login_without_timeout(
         self, initialized_client: Mt5Client, mock_mt5: Mock

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -155,24 +155,26 @@ class TestMt5Client:
 
         assert result is False
 
-    def test_version(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
-        """Test version method."""
-        mock_mt5.version.return_value = (500, 3815, "01 Dec 2023")
-
-        result = initialized_client.version()
-
-        assert result == (500, 3815, "01 Dec 2023")
-        mock_mt5.version.assert_called_once()
-
-    def test_version_failure(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize(
+        ("return_value", "expected"),
+        [
+            ((500, 3815, "01 Dec 2023"), (500, 3815, "01 Dec 2023")),
+            (None, None),
+        ],
+        ids=["success", "failure"],
+    )
+    def test_version(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        return_value: tuple[int, int, str] | None,
+        expected: tuple[int, int, str] | None,
     ) -> None:
-        """Test version method failure."""
-        mock_mt5.version.return_value = None
-
+        """Test version method."""
+        mock_mt5.version.return_value = return_value
         result = initialized_client.version()
-
-        assert result is None
+        assert result == expected
+        mock_mt5.version.assert_called_once()
 
     @pytest.mark.parametrize(
         ("method_name", "return_value"),

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -462,7 +461,15 @@ class TestMt5Client:
         ("method_name", "kwargs"),
         [
             ("history_orders_get", {"ticket": 12345}),
+            ("history_orders_get", {"position": 54321}),
+            ("history_deals_get", {"ticket": 12345}),
             ("history_deals_get", {"position": 54321}),
+        ],
+        ids=[
+            "orders-by-ticket",
+            "orders-by-position",
+            "deals-by-ticket",
+            "deals-by-position",
         ],
     )
     def test_history_get_by_id(
@@ -473,7 +480,7 @@ class TestMt5Client:
         method_name: str,
         kwargs: dict[str, int],
     ) -> None:
-        """Test history_orders_get by ticket and history_deals_get by position."""
+        """Test ID filters for history_orders_get and history_deals_get."""
         mock_item = mocker.MagicMock()
         getattr(mock_mt5, method_name).return_value = (mock_item,)
 
@@ -493,23 +500,43 @@ class TestMt5Client:
         assert result == ()
         mock_mt5.history_orders_get.assert_called_once_with(None, None)
 
-    def test_method_not_initialized(self, client: Mt5Client) -> None:
-        """Test calling methods when not initialized."""
-        methods: list[tuple[str, list[Any]]] = [
-            ("symbols_total", []),
-            ("symbols_get", []),
-            ("symbol_info", ["EURUSD"]),
-            ("account_info", []),
-            ("terminal_info", []),
-            ("orders_total", []),
-            ("positions_total", []),
-        ]
+    @pytest.mark.parametrize(
+        ("method_name", "args", "mt5_return_value"),
+        [
+            ("symbols_total", [], 0),
+            ("orders_total", [], 0),
+            ("positions_total", [], 0),
+            ("symbol_info", ["EURUSD"], None),
+            ("account_info", [], None),
+            ("terminal_info", [], None),
+        ],
+        ids=[
+            "symbols_total",
+            "orders_total",
+            "positions_total",
+            "symbol_info",
+            "account_info",
+            "terminal_info",
+        ],
+    )
+    def test_method_not_initialized(
+        self,
+        client: Mt5Client,
+        mock_mt5: Mock,
+        mocker: MockerFixture,
+        method_name: str,
+        args: list[Any],
+        mt5_return_value: int | None,
+    ) -> None:
+        """Test that methods auto-initialize before delegating to the MT5 module."""
+        mock_mt5.initialize.return_value = True
+        safe_val = mocker.MagicMock() if mt5_return_value is None else mt5_return_value
+        getattr(mock_mt5, method_name).return_value = safe_val
 
-        for method_name, args in methods:
-            method = getattr(client, method_name)
-            # Methods should automatically initialize if not already done
-            with contextlib.suppress(Mt5RuntimeError):
-                method(*args)
+        getattr(client, method_name)(*args)
+
+        mock_mt5.initialize.assert_called_once()
+        getattr(mock_mt5, method_name).assert_called_once_with(*args)
 
     def test_error_handling_with_context(
         self, initialized_client: Mt5Client, mock_mt5: Mock

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ name = "metatrader5"
 version = "5.0.5735"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'win32'" },
+    { name = "numpy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/0b/3dd5143f14319dca393a3bcf11ddf24f36f16dfb8c6d1bf2b193ce0c5733/metatrader5-5.0.5735-cp311-cp311-win_amd64.whl", hash = "sha256:0d05b69cef5eb3f43ea47cb6d36dac0e7e15f82a4fb77974439c565daa54d1c9", size = 48091, upload-time = "2026-04-04T16:44:08.677Z" },
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

Consolidate test cases using pytest parametrize to reduce duplication and improve maintainability.

- Consolidate order_calc_profit None-return tests
- Reduce test_mt5.py size by consolidating tests  
- Reduce test_dataframe.py and test_mt5.py size using parametrize

## Test plan

- [x] All existing tests pass
- [x] Branch coverage maintained at 100%