### PR TITLE
test: parametrize remaining repeated test shapes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.0.2"
+version = "1.0.3"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -380,6 +380,21 @@ class MockRate(NamedTuple):
     real_volume: int
 
 
+def _create_mock_rates() -> np.ndarray[Any, np.dtype[Any]]:
+    """Return a minimal mock rates array for copy_rates_* tests."""
+    rate_dtype = np.dtype([
+        ("time", "int64"),
+        ("open", "float64"),
+        ("high", "float64"),
+        ("low", "float64"),
+        ("close", "float64"),
+    ])
+    return np.array(
+        [(1640995200, 1.1300, 1.1350, 1.1280, 1.1320)],
+        dtype=rate_dtype,
+    )
+
+
 class MockOrder(NamedTuple):
     """Mock order structure."""
 
@@ -1596,7 +1611,7 @@ class TestMt5DataClientValidation:
         client_method: str,
         mt5_method: str,
         extra_key: str,
-        extra_value: float,
+        extra_value: int | float,  # noqa: PYI041
     ) -> None:
         """Test order_check_as_dict and order_send_as_dict methods."""
         config = Mt5Config()
@@ -1621,76 +1636,72 @@ class TestMt5DataClientValidation:
 
             assert result["retcode"] == 10009
             assert result["request"] == {"action": 1, "symbol": "EURUSD"}
-            assert result[extra_key] == pytest.approx(extra_value)
+            if isinstance(extra_value, float):
+                assert result[extra_key] == pytest.approx(extra_value)
+            else:
+                assert result[extra_key] == extra_value
 
+    @pytest.mark.parametrize(
+        "count",
+        [
+            pytest.param(1, id="count-one"),
+            pytest.param(10, id="count-ten"),
+        ],
+    )
     def test_copy_rates_from_as_df(
         self,
         mock_mt5_import: ModuleType,
+        count: int,
     ) -> None:
-        """Test copy_rates_from_as_df method to cover validation line."""
+        """Test copy_rates_from_as_df covers positive count validation."""
         config = Mt5Config()
 
-        # Mock rates data
-        rate_dtype = np.dtype([
-            ("time", "int64"),
-            ("open", "float64"),
-            ("high", "float64"),
-            ("low", "float64"),
-            ("close", "float64"),
-        ])
-        mock_rates = np.array(
-            [
-                (1640995200, 1.1300, 1.1350, 1.1280, 1.1320),
-            ],
-            dtype=rate_dtype,
-        )
-
         with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.copy_rates_from.return_value = mock_rates
+            mock_mt5_import.copy_rates_from.return_value = _create_mock_rates()
 
-            # This should trigger the _validate_positive_count call
             result = client.copy_rates_from_as_df(
                 symbol="EURUSD",
                 timeframe=16385,
                 date_from=datetime(2023, 1, 1, tzinfo=UTC),
-                count=10,
+                count=count,
                 index_keys="time",
             )
 
             assert len(result) == 1
             assert "time" in result.index.names
 
+    @pytest.mark.parametrize(
+        ("date_from", "date_to"),
+        [
+            pytest.param(
+                datetime(2023, 1, 1, tzinfo=UTC),
+                datetime(2023, 1, 2, tzinfo=UTC),
+                id="one-day",
+            ),
+            pytest.param(
+                datetime(2023, 1, 1, tzinfo=UTC),
+                datetime(2023, 1, 31, tzinfo=UTC),
+                id="one-month",
+            ),
+        ],
+    )
     def test_copy_rates_range_as_df(
         self,
         mock_mt5_import: ModuleType,
+        date_from: datetime,
+        date_to: datetime,
     ) -> None:
-        """Test copy_rates_range_as_df method to cover validation line."""
+        """Test copy_rates_range_as_df covers date range validation."""
         config = Mt5Config()
 
-        # Mock rates data
-        rate_dtype = np.dtype([
-            ("time", "int64"),
-            ("open", "float64"),
-            ("high", "float64"),
-            ("low", "float64"),
-            ("close", "float64"),
-        ])
-        mock_rates = np.array(
-            [
-                (1640995200, 1.1300, 1.1350, 1.1280, 1.1320),
-            ],
-            dtype=rate_dtype,
-        )
-
         with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.copy_rates_range.return_value = mock_rates
+            mock_mt5_import.copy_rates_range.return_value = _create_mock_rates()
 
-            # This should trigger the _validate_date_range call
             result = client.copy_rates_range_as_df(
                 symbol="EURUSD",
                 timeframe=16385,
-                date_from=datetime(2023, 1, 1, tzinfo=UTC),
-                date_to=datetime(2023, 1, 2, tzinfo=UTC),
+                date_from=date_from,
+                date_to=date_to,
                 index_keys="time",
             )
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1642,68 +1642,72 @@ class TestMt5DataClientValidation:
                 assert result[extra_key] == extra_value
 
     @pytest.mark.parametrize(
-        "count",
+        ("client_method", "mt5_method", "call_kwargs"),
         [
-            pytest.param(1, id="count-one"),
-            pytest.param(10, id="count-ten"),
+            pytest.param(
+                "copy_rates_from_as_df",
+                "copy_rates_from",
+                {
+                    "symbol": "EURUSD",
+                    "timeframe": 16385,
+                    "date_from": datetime(2023, 1, 1, tzinfo=UTC),
+                    "count": 1,
+                    "index_keys": "time",
+                },
+                id="copy_rates_from-count-one",
+            ),
+            pytest.param(
+                "copy_rates_from_as_df",
+                "copy_rates_from",
+                {
+                    "symbol": "EURUSD",
+                    "timeframe": 16385,
+                    "date_from": datetime(2023, 1, 1, tzinfo=UTC),
+                    "count": 10,
+                    "index_keys": "time",
+                },
+                id="copy_rates_from-count-ten",
+            ),
+            pytest.param(
+                "copy_rates_range_as_df",
+                "copy_rates_range",
+                {
+                    "symbol": "EURUSD",
+                    "timeframe": 16385,
+                    "date_from": datetime(2023, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2023, 1, 2, tzinfo=UTC),
+                    "index_keys": "time",
+                },
+                id="copy_rates_range-one-day",
+            ),
+            pytest.param(
+                "copy_rates_range_as_df",
+                "copy_rates_range",
+                {
+                    "symbol": "EURUSD",
+                    "timeframe": 16385,
+                    "date_from": datetime(2023, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2023, 1, 31, tzinfo=UTC),
+                    "index_keys": "time",
+                },
+                id="copy_rates_range-one-month",
+            ),
         ],
     )
-    def test_copy_rates_from_as_df(
+    def test_copy_rates_as_df(
         self,
         mock_mt5_import: ModuleType,
-        count: int,
+        client_method: str,
+        mt5_method: str,
+        call_kwargs: dict[str, Any],
     ) -> None:
-        """Test copy_rates_from_as_df covers positive count validation."""
+        """Test copy_rates_from_as_df and copy_rates_range_as_df."""
         config = Mt5Config()
 
         with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.copy_rates_from.return_value = _create_mock_rates()
+            getattr(mock_mt5_import, mt5_method).return_value = _create_mock_rates()
 
-            result = client.copy_rates_from_as_df(
-                symbol="EURUSD",
-                timeframe=16385,
-                date_from=datetime(2023, 1, 1, tzinfo=UTC),
-                count=count,
-                index_keys="time",
-            )
-
-            assert len(result) == 1
-            assert "time" in result.index.names
-
-    @pytest.mark.parametrize(
-        ("date_from", "date_to"),
-        [
-            pytest.param(
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 2, tzinfo=UTC),
-                id="one-day",
-            ),
-            pytest.param(
-                datetime(2023, 1, 1, tzinfo=UTC),
-                datetime(2023, 1, 31, tzinfo=UTC),
-                id="one-month",
-            ),
-        ],
-    )
-    def test_copy_rates_range_as_df(
-        self,
-        mock_mt5_import: ModuleType,
-        date_from: datetime,
-        date_to: datetime,
-    ) -> None:
-        """Test copy_rates_range_as_df covers date range validation."""
-        config = Mt5Config()
-
-        with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.copy_rates_range.return_value = _create_mock_rates()
-
-            result = client.copy_rates_range_as_df(
-                symbol="EURUSD",
-                timeframe=16385,
-                date_from=date_from,
-                date_to=date_to,
-                index_keys="time",
-            )
+            result = getattr(client, client_method)(**call_kwargs)
 
             assert len(result) == 1
             assert "time" in result.index.names
@@ -2353,63 +2357,53 @@ class TestMt5DataClientCoverageMissing:
         # Price is used as index in market book data
         assert result.index.name == "price"
 
-    def test_order_check_as_df(self, mock_mt5_import: ModuleType) -> None:
-        """Test order_check_as_df method."""
-
-        class MockRequest(NamedTuple):
-            action: int
-            symbol: str
-
-        class MockOrderCheck(NamedTuple):
-            retcode: int
-            margin: float
-            profit: float
-            request: MockRequest
-
-        mock_request = MockRequest(action=1, symbol="EURUSD")
-        mock_order_check = MockOrderCheck(
-            retcode=10009, margin=100.0, profit=50.0, request=mock_request
-        )
-        mock_mt5_import.order_check.return_value = mock_order_check
+    @pytest.mark.parametrize(
+        ("client_method", "mt5_method", "extra_columns"),
+        [
+            pytest.param(
+                "order_check_as_df",
+                "order_check",
+                ("margin", "profit"),
+                id="order_check",
+            ),
+            pytest.param(
+                "order_send_as_df",
+                "order_send",
+                ("deal", "order"),
+                id="order_send",
+            ),
+        ],
+    )
+    def test_order_action_as_df(
+        self,
+        mock_mt5_import: ModuleType,
+        mocker: MockerFixture,
+        client_method: str,
+        mt5_method: str,
+        extra_columns: tuple[str, ...],
+    ) -> None:
+        """Test order_check_as_df and order_send_as_df methods."""
         client = create_initialized_client(mock_mt5_import)
 
+        mock_request = mocker.MagicMock()
+        mock_request._asdict.return_value = {"action": 1, "symbol": "EURUSD"}
+
+        mock_result = mocker.MagicMock()
+        mock_result._asdict.return_value = {
+            "retcode": 10009,
+            "request": mock_request,
+            **dict.fromkeys(extra_columns, 0),
+        }
+        getattr(mock_mt5_import, mt5_method).return_value = mock_result
+
         request = {"action": 1, "symbol": "EURUSD", "volume": 0.1}
-        result = client.order_check_as_df(request)
+        result = getattr(client, client_method)(request)
 
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
         assert "retcode" in result.columns
-        assert "margin" in result.columns
-        assert "profit" in result.columns
-
-    def test_order_send_as_df(self, mock_mt5_import: ModuleType) -> None:
-        """Test order_send_as_df method."""
-
-        class MockRequest(NamedTuple):
-            action: int
-            symbol: str
-
-        class MockOrderSend(NamedTuple):
-            retcode: int
-            deal: int
-            order: int
-            request: MockRequest
-
-        mock_request = MockRequest(action=1, symbol="EURUSD")
-        mock_order_send = MockOrderSend(
-            retcode=10009, deal=12345, order=67890, request=mock_request
-        )
-        mock_mt5_import.order_send.return_value = mock_order_send
-        client = create_initialized_client(mock_mt5_import)
-
-        request = {"action": 1, "symbol": "EURUSD", "volume": 0.1}
-        result = client.order_send_as_df(request)
-
-        assert isinstance(result, pd.DataFrame)
-        assert len(result) == 1
-        assert "retcode" in result.columns
-        assert "deal" in result.columns
-        assert "order" in result.columns
+        for col in extra_columns:
+            assert col in result.columns
 
     @pytest.mark.parametrize(
         ("input_dict", "kwargs", "expected"),

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,6 +1,6 @@
 """Tests for pdmt5.dataframe module."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import UTC, datetime
 from types import ModuleType
 from typing import Any, NamedTuple, cast
@@ -491,6 +491,109 @@ class MockBookInfo(NamedTuple):
     price: float
     volume: float
     volume_real: float
+
+
+class _MockOrderNoTimeExpiration:
+    """Mock order row omitting the time_expiration column."""
+
+    def _asdict(self) -> dict[str, Any]:
+        return {
+            "ticket": 123456,
+            "time_setup": 1640995200,
+            "time_setup_msc": 1640995200000,
+            "time_done": 0,
+            "time_done_msc": 0,
+            "type": 0,
+            "type_time": 0,
+            "type_filling": 0,
+            "state": 1,
+            "magic": 0,
+            "position_id": 0,
+            "position_by_id": 0,
+            "reason": 0,
+            "volume_initial": 0.1,
+            "volume_current": 0.1,
+            "price_open": 1.1300,
+            "sl": 1.1200,
+            "tp": 1.1400,
+            "price_current": 1.1301,
+            "price_stoplimit": 0.0,
+            "symbol": "EURUSD",
+            "comment": "",
+            "external_id": "",
+        }
+
+
+class _MockPositionNoTimeUpdate:
+    """Mock position row omitting the time_update column."""
+
+    def _asdict(self) -> dict[str, Any]:
+        return {
+            "ticket": 123456,
+            "time": 1640995200,
+            "time_msc": 1640995200000,
+            "time_update_msc": 1640995200000,
+            "type": 0,
+            "magic": 0,
+            "identifier": 123456,
+            "reason": 0,
+            "volume": 0.1,
+            "price_open": 1.1300,
+            "sl": 1.1200,
+            "tp": 1.1400,
+            "price_current": 1.1301,
+            "swap": 0.0,
+            "profit": 10.0,
+            "symbol": "EURUSD",
+            "comment": "",
+            "external_id": "",
+        }
+
+
+class _MockOrderNoTimeDone:
+    """Mock history order row omitting the time_done column."""
+
+    def _asdict(self) -> dict[str, Any]:
+        return {
+            "ticket": 123456,
+            "time_setup": 1640995200,
+            "time_setup_msc": 1640995200000,
+            "time_done_msc": 0,
+            "time_expiration": 0,
+            "type": 0,
+            "type_time": 0,
+            "type_filling": 0,
+            "state": 1,
+            "magic": 0,
+            "position_id": 0,
+            "position_by_id": 0,
+            "reason": 0,
+            "volume_initial": 0.1,
+            "volume_current": 0.1,
+            "price_open": 1.1300,
+            "sl": 1.1200,
+            "tp": 1.1400,
+            "price_current": 1.1301,
+            "price_stoplimit": 0.0,
+            "symbol": "EURUSD",
+            "comment": "",
+            "external_id": "",
+        }
+
+
+def _mock_order_no_time_expiration() -> object:
+    """Factory for an order row without time_expiration."""
+    return _MockOrderNoTimeExpiration()
+
+
+def _mock_position_no_time_update() -> object:
+    """Factory for a position row without time_update."""
+    return _MockPositionNoTimeUpdate()
+
+
+def _mock_order_no_time_done() -> object:
+    """Factory for a history order row without time_done."""
+    return _MockOrderNoTimeDone()
 
 
 class TestMt5Config:
@@ -1197,13 +1300,31 @@ class TestMt5DataClient:
             *expected_mt5_args, **expected_mt5_kwargs
         )
 
-    def test_history_orders_get_no_dates(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        ("client_method", "mt5_method"),
+        [
+            pytest.param(
+                "history_orders_get_as_df",
+                "history_orders_get",
+                id="history_orders",
+            ),
+            pytest.param(
+                "history_deals_get_as_df",
+                "history_deals_get",
+                id="history_deals",
+            ),
+        ],
+    )
+    def test_history_get_no_dates(
+        self,
+        mock_mt5_import: ModuleType | None,
+        client_method: str,
+        mt5_method: str,
     ) -> None:
-        """Test history_orders_get method without dates when not using ticket."""
+        """Test history methods without dates when not using ticket or position."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_orders_get.return_value = []
+        getattr(mock_mt5_import, mt5_method).return_value = []
         mock_mt5_import.last_error.return_value = (1, "Invalid arguments")
 
         client = create_initialized_client(mock_mt5_import)
@@ -1214,7 +1335,7 @@ class TestMt5DataClient:
                 r" if not using ticket or position"
             ),
         ):
-            client.history_orders_get_as_df()
+            getattr(client, client_method)()
 
     def test_history_orders_get_invalid_dates(
         self, mock_mt5_import: ModuleType | None
@@ -1241,25 +1362,6 @@ class TestMt5DataClient:
         )
         assert orders_df.empty
         assert isinstance(orders_df, pd.DataFrame)
-
-    def test_history_deals_get_no_dates(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_deals_get method without dates when not using ticket."""
-        assert mock_mt5_import is not None
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_deals_get.return_value = []
-        mock_mt5_import.last_error.return_value = (1, "Invalid arguments")
-
-        client = create_initialized_client(mock_mt5_import)
-        with pytest.raises(
-            ValueError,
-            match=(
-                r"Both date_from and date_to must be provided"
-                r" if not using ticket or position"
-            ),
-        ):
-            client.history_deals_get_as_df()
 
     def test_market_book_get(self, mock_mt5_import: ModuleType | None) -> None:
         """Test market_book_get method."""
@@ -1316,140 +1418,62 @@ class TestMt5DataClient:
 
         mock_mt5_import.shutdown.assert_called_once()
 
-    def test_orders_get_missing_time_columns(
-        self, mock_mt5_import: ModuleType | None
+    @pytest.mark.parametrize(
+        (
+            "client_method",
+            "mt5_method",
+            "row_factory",
+            "missing_column",
+            "extra_args",
+        ),
+        [
+            pytest.param(
+                "orders_get_as_df",
+                "orders_get",
+                _mock_order_no_time_expiration,
+                "time_expiration",
+                (),
+                id="orders-missing-time_expiration",
+            ),
+            pytest.param(
+                "positions_get_as_df",
+                "positions_get",
+                _mock_position_no_time_update,
+                "time_update",
+                (),
+                id="positions-missing-time_update",
+            ),
+            pytest.param(
+                "history_orders_get_as_df",
+                "history_orders_get",
+                _mock_order_no_time_done,
+                "time_done",
+                (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)),
+                id="history-orders-missing-time_done",
+            ),
+        ],
+    )
+    def test_get_missing_time_columns(
+        self,
+        mock_mt5_import: ModuleType | None,
+        client_method: str,
+        mt5_method: str,
+        row_factory: Callable[[], object],
+        missing_column: str,
+        extra_args: tuple[Any, ...],
     ) -> None:
-        """Test orders_get when some time columns are missing."""
+        """Test DataFrame methods when expected time columns are missing."""
         assert mock_mt5_import is not None
-        # Create mock orders data as dict without time_expiration
-
-        class MockOrderNoTimeExpiration:
-            def _asdict(self) -> dict[str, Any]:
-                return {
-                    "ticket": 123456,
-                    "time_setup": 1640995200,
-                    "time_setup_msc": 1640995200000,
-                    "time_done": 0,
-                    "time_done_msc": 0,
-                    "type": 0,
-                    "type_time": 0,
-                    "type_filling": 0,
-                    "state": 1,
-                    "magic": 0,
-                    "position_id": 0,
-                    "position_by_id": 0,
-                    "reason": 0,
-                    "volume_initial": 0.1,
-                    "volume_current": 0.1,
-                    "price_open": 1.1300,
-                    "sl": 1.1200,
-                    "tp": 1.1400,
-                    "price_current": 1.1301,
-                    "price_stoplimit": 0.0,
-                    "symbol": "EURUSD",
-                    "comment": "",
-                    "external_id": "",
-                }
+        mock_mt5_import.initialize.return_value = True
+        getattr(mock_mt5_import, mt5_method).return_value = [row_factory()]
 
         client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.orders_get.return_value = [MockOrderNoTimeExpiration()]
-
         client.initialize()
-        df_result = client.orders_get_as_df()
+        df_result = getattr(client, client_method)(*extra_args)
 
         assert isinstance(df_result, pd.DataFrame)
         assert len(df_result) == 1
-        assert "time_expiration" not in df_result.columns
-
-    def test_positions_get_missing_time_columns(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test positions_get when some time columns are missing."""
-        assert mock_mt5_import is not None
-        # Create mock positions data as dict without time_update
-
-        class MockPositionNoTimeUpdate:
-            def _asdict(self) -> dict[str, Any]:
-                return {
-                    "ticket": 123456,
-                    "time": 1640995200,
-                    "time_msc": 1640995200000,
-                    "time_update_msc": 1640995200000,
-                    "type": 0,
-                    "magic": 0,
-                    "identifier": 123456,
-                    "reason": 0,
-                    "volume": 0.1,
-                    "price_open": 1.1300,
-                    "sl": 1.1200,
-                    "tp": 1.1400,
-                    "price_current": 1.1301,
-                    "swap": 0.0,
-                    "profit": 10.0,
-                    "symbol": "EURUSD",
-                    "comment": "",
-                    "external_id": "",
-                }
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.positions_get.return_value = [MockPositionNoTimeUpdate()]
-
-        client.initialize()
-        df_result = client.positions_get_as_df()
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert "time_update" not in df_result.columns
-
-    def test_history_orders_get_missing_time_columns(
-        self, mock_mt5_import: ModuleType | None
-    ) -> None:
-        """Test history_orders_get when some time columns are missing."""
-        assert mock_mt5_import is not None
-        # Create mock orders data as dict without time_done
-
-        class MockOrderNoTimeDone:
-            def _asdict(self) -> dict[str, Any]:
-                return {
-                    "ticket": 123456,
-                    "time_setup": 1640995200,
-                    "time_setup_msc": 1640995200000,
-                    "time_done_msc": 0,
-                    "time_expiration": 0,
-                    "type": 0,
-                    "type_time": 0,
-                    "type_filling": 0,
-                    "state": 1,
-                    "magic": 0,
-                    "position_id": 0,
-                    "position_by_id": 0,
-                    "reason": 0,
-                    "volume_initial": 0.1,
-                    "volume_current": 0.1,
-                    "price_open": 1.1300,
-                    "sl": 1.1200,
-                    "tp": 1.1400,
-                    "price_current": 1.1301,
-                    "price_stoplimit": 0.0,
-                    "symbol": "EURUSD",
-                    "comment": "",
-                    "external_id": "",
-                }
-
-        client = Mt5DataClient(mt5=mock_mt5_import)
-        mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.history_orders_get.return_value = [MockOrderNoTimeDone()]
-
-        client.initialize()
-        df_result = client.history_orders_get_as_df(
-            datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 1, 2, tzinfo=UTC)
-        )
-
-        assert isinstance(df_result, pd.DataFrame)
-        assert len(df_result) == 1
-        assert "time_done" not in df_result.columns
+        assert missing_column not in df_result.columns
 
 
 class TestMt5DataClientValidation:
@@ -1546,15 +1570,38 @@ class TestMt5DataClientValidation:
                 position=-1
             )
 
-    def test_order_check_as_dict(
+    @pytest.mark.parametrize(
+        ("client_method", "mt5_method", "extra_key", "extra_value"),
+        [
+            pytest.param(
+                "order_check_as_dict",
+                "order_check",
+                "volume",
+                1.0,
+                id="order_check",
+            ),
+            pytest.param(
+                "order_send_as_dict",
+                "order_send",
+                "order",
+                12345,
+                id="order_send",
+            ),
+        ],
+    )
+    def test_order_action_as_dict(
         self,
         mock_mt5_import: ModuleType,
         mocker: MockerFixture,
+        client_method: str,
+        mt5_method: str,
+        extra_key: str,
+        extra_value: float,
     ) -> None:
-        """Test order_check_as_dict method."""
+        """Test order_check_as_dict and order_send_as_dict methods."""
         config = Mt5Config()
 
-        # Mock order check result with nested structure
+        # Mock order action result with nested request structure
         mock_request = mocker.MagicMock()
         mock_request._asdict.return_value = {"action": 1, "symbol": "EURUSD"}
 
@@ -1562,49 +1609,19 @@ class TestMt5DataClientValidation:
         mock_result._asdict.return_value = {
             "retcode": 10009,
             "request": mock_request,
-            "volume": 1.0,
+            extra_key: extra_value,
         }
 
         with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.order_check.return_value = mock_result
+            getattr(mock_mt5_import, mt5_method).return_value = mock_result
 
-            result = client.order_check_as_dict(
+            result = getattr(client, client_method)(
                 request={"action": 1, "symbol": "EURUSD"}
             )
 
             assert result["retcode"] == 10009
             assert result["request"] == {"action": 1, "symbol": "EURUSD"}
-            assert result["volume"] == pytest.approx(1.0)
-
-    def test_order_send_as_dict(
-        self,
-        mock_mt5_import: ModuleType,
-        mocker: MockerFixture,
-    ) -> None:
-        """Test order_send_as_dict method."""
-        config = Mt5Config()
-
-        # Mock order send result with nested structure
-        mock_request = mocker.MagicMock()
-        mock_request._asdict.return_value = {"action": 1, "symbol": "EURUSD"}
-
-        mock_result = mocker.MagicMock()
-        mock_result._asdict.return_value = {
-            "retcode": 10009,
-            "request": mock_request,
-            "order": 12345,
-        }
-
-        with Mt5DataClient(mt5=mock_mt5_import, config=config) as client:
-            mock_mt5_import.order_send.return_value = mock_result
-
-            result = client.order_send_as_dict(
-                request={"action": 1, "symbol": "EURUSD"}
-            )
-
-            assert result["retcode"] == 10009
-            assert result["request"] == {"action": 1, "symbol": "EURUSD"}
-            assert result["order"] == 12345
+            assert result[extra_key] == pytest.approx(extra_value)
 
     def test_copy_rates_from_as_df(
         self,

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -763,25 +763,30 @@ class TestMt5Client:
             date_from, date_to, group="*USD*"
         )
 
-    @pytest.mark.parametrize("method_name", ["orders_get", "positions_get"])
+    @pytest.mark.parametrize(
+        ("method_name", "kwargs"),
+        [
+            pytest.param("orders_get", {"group": "*USD*"}, id="orders-group"),
+            pytest.param("orders_get", {"ticket": 12345}, id="orders-ticket"),
+            pytest.param("positions_get", {"group": "*USD*"}, id="positions-group"),
+            pytest.param("positions_get", {"ticket": 12345}, id="positions-ticket"),
+        ],
+    )
     def test_get_methods_with_parameters(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
         mocker: MockerFixture,
         method_name: str,
+        kwargs: dict[str, Any],
     ) -> None:
-        """Test orders_get and positions_get with different parameter combinations."""
+        """Test orders_get and positions_get with method_name x kwargs cases."""
         mock_item = mocker.MagicMock()
         getattr(mock_mt5, method_name).return_value = (mock_item,)
 
-        result = getattr(initialized_client, method_name)(group="*USD*")
+        result = getattr(initialized_client, method_name)(**kwargs)
         assert result is not None
-        getattr(mock_mt5, method_name).assert_called_with(group="*USD*")
-
-        result = getattr(initialized_client, method_name)(ticket=12345)
-        assert result is not None
-        getattr(mock_mt5, method_name).assert_called_with(ticket=12345)
+        getattr(mock_mt5, method_name).assert_called_with(**kwargs)
 
     def test_login_without_timeout(
         self, initialized_client: Mt5Client, mock_mt5: Mock

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 """Test cases for pdmt5.utils module."""
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 import pytest
@@ -227,46 +227,66 @@ class TestConvertTimeColumnsInDf:
             assert value == expected_value
 
 
+def _assert_dict_time_converted(result: object) -> None:
+    assert isinstance(result, dict)
+    time = cast("object", result["time"])
+    assert isinstance(time, pd.Timestamp)
+    assert time == pd.Timestamp("2024-01-01 00:00:00")
+
+
+def _assert_list_time_converted(result: object) -> None:
+    assert isinstance(result, list)
+    result_list = cast("list[Any]", result)
+    assert len(result_list) == 2
+    assert all(isinstance(d["time"], pd.Timestamp) for d in result_list)
+
+
+def _assert_dataframe_time_converted(result: object) -> None:
+    assert isinstance(result, pd.DataFrame)
+    assert result["time"].dtype == "datetime64[ns]"
+
+
 class TestDetectAndConvertTimeToDatetime:
     """Test detect_and_convert_time_to_datetime decorator."""
 
-    def test_decorator_with_dict_result(self) -> None:
-        """Test decorator with function returning dict."""
+    @pytest.mark.parametrize(
+        ("return_factory", "assert_result"),
+        [
+            pytest.param(
+                lambda: {"time": 1704067200, "price": 100.5},
+                _assert_dict_time_converted,
+                id="dict",
+            ),
+            pytest.param(
+                lambda: [
+                    {"time": 1704067200, "price": 100.5},
+                    {"time": 1704067260, "price": 100.6},
+                ],
+                _assert_list_time_converted,
+                id="list-of-dicts",
+            ),
+            pytest.param(
+                lambda: pd.DataFrame({
+                    "time": [1704067200, 1704067260],
+                    "price": [100.5, 100.6],
+                }),
+                _assert_dataframe_time_converted,
+                id="dataframe",
+            ),
+        ],
+    )
+    def test_decorator_with_normal_results(
+        self,
+        return_factory: Callable[[], Any],
+        assert_result: Callable[[object], None],
+    ) -> None:
+        """Test decorator with dict, list of dicts, and DataFrame results."""
 
         @detect_and_convert_time_to_datetime()
-        def get_data() -> dict[str, Any]:
-            return {"time": 1704067200, "price": 100.5}
+        def get_data() -> Any:  # noqa: ANN401
+            return return_factory()
 
-        result = get_data()
-        assert isinstance(result["time"], pd.Timestamp)
-        assert result["time"] == pd.Timestamp("2024-01-01 00:00:00")
-
-    def test_decorator_with_list_result(self) -> None:
-        """Test decorator with function returning list of dicts."""
-
-        @detect_and_convert_time_to_datetime()
-        def get_data() -> list[dict[str, Any]]:
-            return [
-                {"time": 1704067200, "price": 100.5},
-                {"time": 1704067260, "price": 100.6},
-            ]
-
-        result = get_data()
-        assert len(result) == 2
-        assert all(isinstance(d["time"], pd.Timestamp) for d in result)
-
-    def test_decorator_with_dataframe_result(self) -> None:
-        """Test decorator with function returning DataFrame."""
-
-        @detect_and_convert_time_to_datetime()
-        def get_data() -> pd.DataFrame:
-            return pd.DataFrame({
-                "time": [1704067200, 1704067260],
-                "price": [100.5, 100.6],
-            })
-
-        result = get_data()
-        assert result["time"].dtype == "datetime64[ns]"
+        assert_result(get_data())
 
     def test_decorator_with_skip_toggle(self) -> None:
         """Test decorator with skip_toggle parameter."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -325,32 +325,50 @@ class TestDetectAndConvertTimeToDatetime:
 class TestSetIndexIfPossible:
     """Test set_index_if_possible decorator."""
 
-    def test_decorator_with_index_parameter(self) -> None:
-        """Test decorator with index parameter provided."""
+    @pytest.mark.parametrize(
+        ("decorator_kwargs", "call_kwargs", "expected_index"),
+        [
+            pytest.param(
+                {"index_parameters": "index_keys"},
+                {"index_keys": "symbol"},
+                "symbol",
+                id="with-index-parameter",
+            ),
+            pytest.param(
+                {"index_parameters": "index_keys"},
+                {},
+                pd.RangeIndex,
+                id="without-index-parameter",
+            ),
+            pytest.param(
+                {},
+                {},
+                pd.RangeIndex,
+                id="no-index-parameters-configured",
+            ),
+        ],
+    )
+    def test_decorator_with_normal_dataframe(
+        self,
+        decorator_kwargs: dict[str, Any],
+        call_kwargs: dict[str, Any],
+        expected_index: type[pd.RangeIndex] | str,
+    ) -> None:
+        """Test decorator with normal DataFrames and varied index configuration."""
 
-        @set_index_if_possible(index_parameters="index_keys")
+        @set_index_if_possible(**decorator_kwargs)
         def get_data(index_keys: str | None = None) -> pd.DataFrame:  # noqa: ARG001
             return pd.DataFrame({
                 "symbol": ["EURUSD", "GBPUSD"],
                 "price": [1.1, 1.3],
             })
 
-        result = get_data(index_keys="symbol")
-        assert result.index.name == "symbol"
-        assert list(result.index) == ["EURUSD", "GBPUSD"]
-
-    def test_decorator_without_index_parameter(self) -> None:
-        """Test decorator without index parameter."""
-
-        @set_index_if_possible(index_parameters="index_keys")
-        def get_data(index_keys: str | None = None) -> pd.DataFrame:  # noqa: ARG001
-            return pd.DataFrame({
-                "symbol": ["EURUSD", "GBPUSD"],
-                "price": [1.1, 1.3],
-            })
-
-        result = get_data()
-        assert isinstance(result.index, pd.RangeIndex)
+        result = get_data(**call_kwargs)
+        if isinstance(expected_index, str):
+            assert result.index.name == expected_index
+            assert list(result.index) == ["EURUSD", "GBPUSD"]
+        else:
+            assert isinstance(result.index, expected_index)
 
     def test_decorator_with_empty_dataframe(self) -> None:
         """Test decorator with empty DataFrame."""
@@ -377,19 +395,6 @@ class TestSetIndexIfPossible:
             ),
         ):
             get_data()
-
-    def test_decorator_with_no_index_parameters(self) -> None:
-        """Test decorator with no index_parameters specified."""
-
-        @set_index_if_possible()
-        def get_data() -> pd.DataFrame:
-            return pd.DataFrame({
-                "symbol": ["EURUSD", "GBPUSD"],
-                "price": [1.1, 1.3],
-            })
-
-        result = get_data()
-        assert isinstance(result.index, pd.RangeIndex)
 
     def test_decorator_preserves_function_metadata(self) -> None:
         """Test decorator preserves original function metadata."""

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
Refactor remaining repeated test shapes in `tests/test_dataframe.py` and `tests/test_mt5.py` to use `pytest.mark.parametrize`.

### Changes
- Combined `copy_rates_from_as_df` and `copy_rates_range_as_df` into one parametrized test using `client_method`, `mt5_method`, and `call_kwargs`.
- Combined `order_check_as_df` and `order_send_as_df` into one parametrized test, preserving the request/result column assertions via `mocker.MagicMock` for the request/result rows.
- Split `test_get_methods_with_parameters` into `method_name × kwargs` cases so `group` and `ticket` are separate cases per method (`orders_get`, `positions_get`).
- Bumped package version to 1.0.3.

### Design notes
- Diff is minimal: each parametrize keeps the same call shape, mock setup, and assertions as the originals.
- No broad helper abstractions for large mock rows; the `order_action_as_df` mock uses the same `mocker.MagicMock` approach as the existing `order_action_as_dict` test.
- Existing test semantics preserved (column assertions, call shape, and validation paths).

### QA
- `uv run ruff format`
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest` — 324 passed, 33 skipped, 100% coverage
- `./.agents/skills/local-qa/scripts/qa.sh` — green