### PR TITLE
Fix MT5 initialization and sdist bug regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ High-level trading orchestration (market-order construction, margin-budget sizin
 - **Comprehensive MT5 Coverage**: Account info, market data, tick data, orders, positions, and more
 - **Canonical MT5 Constants**: Shared parsing for timeframes, COPY_TICKS flags,
   and ORDER_TYPE values with official names, short aliases, or valid integers
-- **Context Manager Support**: Clean initialization and cleanup with `with` statements (initialize only)
+- **Context Manager Support**: Clean initialization and cleanup with `with` statements; `Mt5DataClient` applies `Mt5Config` automatically
 - **Time Series Ready**: OHLCV data with proper datetime indexing
 - **Robust Error Handling**: Custom exceptions with detailed MT5 error information
 - **Direct Order Primitives**: `order_check` / `order_send` wrappers with DataFrame/dict conversions
@@ -60,9 +60,6 @@ config = Mt5Config(
 
 # Use as context manager
 with Mt5DataClient(config=config) as client:
-    # Optional: login when credentials are provided
-    client.login(config.login, config.password, config.server)
-
     # Get account information as DataFrame
     account_info = client.account_info_as_df()
     print(account_info)

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -120,22 +120,26 @@ class Mt5DataClient(Mt5Client):
                     self.retry_count,
                 )
                 time.sleep(i)
-            if self.initialize(
+            if not self.initialize(
                 path=path,
                 login=login_value,
                 password=password_value,
                 server=server_value,
                 timeout=timeout_value,
-            ) and (
-                login_value is None
-                or self.login(
+            ):
+                continue
+            try:
+                if login_value is None or self.login(
                     login=login_value,
                     password=password_value,
                     server=server_value,
                     timeout=timeout_value,
-                )
-            ):
-                return
+                ):
+                    return
+            except Exception:
+                self.shutdown()
+                raise
+            self.shutdown()
         error_message = (
             f"MT5 initialize and login failed after {self.retry_count} retries:"
             f" {self.last_error()}"

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime  # noqa: TC003
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
@@ -52,6 +52,15 @@ class Mt5DataClient(Mt5Client):
         ge=0,
         description="Number of retry attempts for connection initialization",
     )
+
+    def __enter__(self) -> Self:
+        """Context manager entry using config-aware initialization.
+
+        Returns:
+            The initialized client instance.
+        """
+        self.initialize_and_login_mt5()
+        return self
 
     @staticmethod
     def _as_dicts(items: Any) -> list[dict[str, Any]]:  # noqa: ANN401

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -126,6 +126,16 @@ class Mt5Client(BaseModel):
         Returns:
             True if successful, False otherwise.
         """
+        initialize_kwargs = {
+            k: v
+            for k, v in {
+                "login": login,
+                "password": password,
+                "server": server,
+                "timeout": timeout,
+            }.items()
+            if v is not None
+        }
         if path is not None:
             logger.info(
                 "Initializing MT5 connection with path: %s",
@@ -133,17 +143,11 @@ class Mt5Client(BaseModel):
             )
             self._is_initialized = self.mt5.initialize(
                 path,
-                **{
-                    k: v
-                    for k, v in {
-                        "login": login,
-                        "password": password,
-                        "server": server,
-                        "timeout": timeout,
-                    }.items()
-                    if v is not None
-                },
+                **initialize_kwargs,
             )
+        elif initialize_kwargs:
+            logger.info("Initializing MT5 connection with parameters.")
+            self._is_initialized = self.mt5.initialize(**initialize_kwargs)
         else:
             logger.info("Initializing MT5 connection.")
             self._is_initialized = self.mt5.initialize()
@@ -200,7 +204,12 @@ class Mt5Client(BaseModel):
         """
         self._initialize_if_needed()
         logger.info("Retrieving MT5 version information.")
-        return self.mt5.version()
+        response = self.mt5.version()
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="version",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def last_error(self) -> tuple[int, str]:

--- a/pdmt5/utils.py
+++ b/pdmt5/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
@@ -32,10 +33,13 @@ def detect_and_convert_time_to_datetime(
     """
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        signature = inspect.signature(func)
+
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound_arguments = signature.bind_partial(*args, **kwargs).arguments
             result = func(*args, **kwargs)
-            if skip_toggle and kwargs.get(skip_toggle):
+            if skip_toggle and bound_arguments.get(skip_toggle):
                 return result
             elif isinstance(result, dict):
                 return cast(
@@ -118,8 +122,11 @@ def set_index_if_possible(
     def decorator(
         func: Callable[P, pd.DataFrame],
     ) -> Callable[P, pd.DataFrame]:
+        signature = inspect.signature(func)
+
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> pd.DataFrame:
+            bound_arguments = signature.bind_partial(*args, **kwargs).arguments
             result = func(*args, **kwargs)
             if not isinstance(result, pd.DataFrame):  # type: ignore[reportUnnecessaryIsInstance]
                 error_message = (
@@ -127,8 +134,12 @@ def set_index_if_possible(
                     f"{type(result).__name__}. Expected DataFrame."
                 )
                 raise TypeError(error_message)
-            elif index_parameters and kwargs.get(index_parameters) and not result.empty:
-                return result.set_index(kwargs[index_parameters])
+            elif (
+                index_parameters
+                and bound_arguments.get(index_parameters)
+                and not result.empty
+            ):
+                return result.set_index(bound_arguments[index_parameters])
             else:
                 return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,8 @@ dev = [
   "mkdocstrings[python] >= 1.0.4",
 ]
 
-[tool.uv.build-backend]
-source-include = ["pdmt5/**", "LICENSE"]
-source-exclude = ["tests/**"]
+[tool.hatch.build.targets.sdist]
+only-include = ["pdmt5", "LICENSE", "README.md", "pyproject.toml"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.0.3"
+version = "1.0.4"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -781,6 +781,85 @@ class TestMt5DataClient:
         )
         mock_mt5_import.shutdown.assert_called_once()
 
+    def test_context_manager_shuts_down_after_login_failure(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test context manager cleans up initialized MT5 state after login failure."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        mock_mt5_import.login.return_value = False
+        mock_mt5_import.last_error.return_value = (1, "Login failed")
+        config = Mt5Config(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+
+        with (
+            pytest.raises(
+                Mt5RuntimeError,
+                match=r"MT5 initialize and login failed after 0 retries:",
+            ),
+            Mt5DataClient(
+                mt5=mock_mt5_import,
+                config=config,
+                retry_count=0,
+            ),
+        ):
+            pass
+
+        mock_mt5_import.shutdown.assert_called_once()
+
+    def test_initialize_and_login_retries_after_login_failure(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test login failure triggers cleanup before a successful retry."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.side_effect = [True, True]
+        mock_mt5_import.login.side_effect = [False, True]
+        config = Mt5Config(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        client = Mt5DataClient(
+            mt5=mock_mt5_import,
+            config=config,
+            retry_count=1,
+        )
+
+        client.initialize_and_login_mt5()
+
+        assert mock_mt5_import.initialize.call_count == 2
+        assert mock_mt5_import.login.call_count == 2
+        mock_mt5_import.shutdown.assert_called_once()
+
+    def test_initialize_and_login_shuts_down_after_login_exception(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test login exceptions trigger shutdown before the error is re-raised."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        mock_mt5_import.login.side_effect = RuntimeError("Login crashed")
+        config = Mt5Config(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        client = Mt5DataClient(
+            mt5=mock_mt5_import,
+            config=config,
+            retry_count=0,
+        )
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 login failed with error:"):
+            client.initialize_and_login_mt5()
+
+        mock_mt5_import.shutdown.assert_called_once()
+
     @pytest.mark.parametrize(
         ("client_method", "mt5_method"),
         [

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -743,6 +743,44 @@ class TestMt5DataClient:
 
         mock_mt5_import.shutdown.assert_called_once()
 
+    def test_context_manager_uses_config_and_retries(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test context manager uses config credentials and retry_count."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.side_effect = [False, True]
+        mock_mt5_import.login.return_value = True
+        config = Mt5Config(
+            path="/path/to/mt5.exe",
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+
+        with Mt5DataClient(
+            mt5=mock_mt5_import,
+            config=config,
+            retry_count=1,
+        ) as client:
+            assert client._is_initialized is True  # type: ignore[reportPrivateUsage]
+
+        assert mock_mt5_import.initialize.call_count == 2
+        mock_mt5_import.initialize.assert_any_call(
+            "/path/to/mt5.exe",
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        mock_mt5_import.login.assert_called_once_with(
+            123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        mock_mt5_import.shutdown.assert_called_once()
+
     @pytest.mark.parametrize(
         ("client_method", "mt5_method"),
         [
@@ -1118,24 +1156,27 @@ class TestMt5DataClient:
             client.order_calc_profit(*args)
         assert context_substr in str(exc_info.value)
 
-    @pytest.mark.parametrize(
-        "return_value",
-        [(2460, 2460, "15 Feb 2022"), None],
-    )
-    def test_version(
-        self,
-        mock_mt5_import: ModuleType | None,
-        return_value: tuple[int, int, str] | None,
-    ) -> None:
-        """Test version with a value and None."""
+    def test_version(self, mock_mt5_import: ModuleType | None) -> None:
+        """Test version with a value."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
-        mock_mt5_import.version.return_value = return_value
+        mock_mt5_import.version.return_value = (2460, 2460, "15 Feb 2022")
 
         client = create_initialized_client(mock_mt5_import)
         result = client.version()
 
-        assert result == return_value
+        assert result == (2460, 2460, "15 Feb 2022")
+
+    def test_version_raises_on_none(self, mock_mt5_import: ModuleType | None) -> None:
+        """Test version raises Mt5RuntimeError on None."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        mock_mt5_import.version.return_value = None
+
+        client = create_initialized_client(mock_mt5_import)
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+            client.version()
 
     @pytest.mark.parametrize("return_value", [1000, None])
     def test_symbols_total(
@@ -2268,6 +2309,19 @@ class TestMt5DataClientCoverageMissing:
         assert "mt5_terminal_version" in result.columns
         assert "build" in result.columns
 
+    def test_version_methods_raise_mt5_runtime_error_on_none_response(
+        self, mock_mt5_import: ModuleType
+    ) -> None:
+        """Test version dictionary/dataframe helpers raise Mt5RuntimeError on None."""
+        mock_mt5_import.version.return_value = None
+        client = create_initialized_client(mock_mt5_import)
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+            client.version_as_dict()
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+            client.version_as_df()
+
     def test_last_error_as_dict(self, mock_mt5_import: ModuleType) -> None:
         """Test last_error_as_dict method."""
         mock_mt5_import.last_error.return_value = (123, "Test error")
@@ -2499,6 +2553,30 @@ class TestMt5DataClientCoverageMissing:
         assert "time" in result.columns
         assert result.index.name == "name"
         assert "EURUSD" in result.index
+
+    def test_symbols_get_methods_honor_positional_skip_and_index_args(
+        self, mock_mt5_import: ModuleType
+    ) -> None:
+        """Test positional skip_to_datetime and index_keys arguments are honored."""
+
+        class MockSymbol:
+            def _asdict(self) -> dict[str, Any]:
+                return {
+                    "name": "EURUSD",
+                    "time": 1640995200,
+                    "bid": 1.1300,
+                    "ask": 1.1301,
+                }
+
+        mock_mt5_import.symbols_get.return_value = [MockSymbol()]
+        client = create_initialized_client(mock_mt5_import)
+
+        dict_result = client.symbols_get_as_dicts(None, True)  # noqa: FBT003
+        assert isinstance(dict_result[0]["time"], int)
+
+        df_result = client.symbols_get_as_df(None, False, "name")  # noqa: FBT003
+        assert df_result.index.name == "name"
+        assert isinstance(df_result["time"].iloc[0], pd.Timestamp)
 
     def test_symbol_info_as_dict_with_skip_to_datetime(
         self, mock_mt5_import: ModuleType

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -96,6 +96,27 @@ class TestMt5Client:
             timeout=60000,
         )
 
+    def test_initialize_with_credentials_without_path(
+        self, client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test initialization passes credentials even without a path."""
+        mock_mt5.initialize.return_value = True
+
+        result = client.initialize(
+            login=12345,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+
+        assert result is True
+        mock_mt5.initialize.assert_called_once_with(
+            login=12345,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+
     def test_initialize_failure(self, client: Mt5Client, mock_mt5: Mock) -> None:
         """Test initialization failure."""
         mock_mt5.initialize.return_value = False
@@ -154,26 +175,27 @@ class TestMt5Client:
 
         assert result is False
 
-    @pytest.mark.parametrize(
-        ("return_value", "expected"),
-        [
-            ((500, 3815, "01 Dec 2023"), (500, 3815, "01 Dec 2023")),
-            (None, None),
-        ],
-        ids=["success", "failure"],
-    )
     def test_version(
         self,
         initialized_client: Mt5Client,
         mock_mt5: Mock,
-        return_value: tuple[int, int, str] | None,
-        expected: tuple[int, int, str] | None,
     ) -> None:
         """Test version method."""
-        mock_mt5.version.return_value = return_value
+        mock_mt5.version.return_value = (500, 3815, "01 Dec 2023")
         result = initialized_client.version()
-        assert result == expected
+        assert result == (500, 3815, "01 Dec 2023")
         mock_mt5.version.assert_called_once()
+
+    def test_version_none_response_raises(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+    ) -> None:
+        """Test version method raises Mt5RuntimeError on None response."""
+        mock_mt5.version.return_value = None
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+            initialized_client.version()
 
     @pytest.mark.parametrize(
         ("method_name", "return_value"),

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary
- preserve initialization credentials even when `Mt5Client.initialize()` is called without a terminal path
- make `Mt5DataClient` context managers honor `Mt5Config` and `retry_count`, and handle `version()` `None` results as `Mt5RuntimeError`
- honor positional `skip_to_datetime` / `index_keys` decorator arguments and move sdist file selection to `hatchling`

## Testing
- `uv run pytest`
- `uv run ruff check .`
- `uv run pyright .`
- `uv build`
- inspected the built sdist to confirm it excludes `tests`, `uv.lock`, `.github`, and `.agents`

Fixes #89
Fixes #90
Fixes #91
Fixes #92
Fixes #94