### PR TITLE
Mask MT5 passwords and fix stale docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 This is a Python package for pandas-friendly MetaTrader 5 access. Core code
 lives in `pdmt5/`: `mt5.py` wraps MT5 calls, `dataframe.py` adds DataFrame/dict
-conversions, `trading.py` contains trading helpers, and `constants.py`/`utils.py`
-hold shared parsing and utilities. Tests live in `tests/`, documentation in
-`docs/`, and project settings in `pyproject.toml`. Keep `uv.lock` in sync.
+conversions, and `constants.py`/`utils.py` hold shared parsing and utilities.
+Tests live in `tests/`, documentation in `docs/`, and project settings in
+`pyproject.toml`. Keep `uv.lock` in sync.
 
 ## Build, Test, and Development Commands
 
@@ -56,7 +56,6 @@ Windows/MT5 assumptions reviewers need to verify.
 
 ## Security & Configuration Tips
 
-Do not commit MT5 account credentials, terminal paths containing secrets, or live
-trading configuration. Use `Mt5Config` inputs or environment-specific setup in
-local scripts. Preserve dry-run pathways and mock-based tests when modifying
-trading behavior.
+Do not commit MT5 account credentials or terminal paths containing secrets. Use
+`Mt5Config` inputs or environment-specific setup in local scripts. Preserve
+mock-based tests when modifying MT5 connection or data-access behavior.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ High-level trading orchestration (market-order construction, margin-budget sizin
   and ORDER_TYPE values with official names, short aliases, or valid integers
 - **Context Manager Support**: Clean initialization and cleanup with `with` statements; `Mt5DataClient` applies `Mt5Config` automatically
 - **Time Series Ready**: OHLCV data with proper datetime indexing
-- **Robust Error Handling**: Custom exceptions with detailed MT5 error information
+- **Robust Error Handling**: Custom exceptions with detailed MT5 failure messages
 - **Direct Order Primitives**: `order_check` / `order_send` wrappers with DataFrame/dict conversions
 
 ## Requirements
@@ -335,7 +335,7 @@ This project maintains high code quality standards:
 
 - **Type Checking**: Strict mode with pyright
 - **Linting**: Comprehensive ruff configuration with 40+ rule categories
-- **Testing**: pytest with coverage tracking (minimum 90%)
+- **Testing**: pytest with 100% branch coverage enforcement
 - **Documentation**: Google-style docstrings
 
 ## Error Handling
@@ -352,8 +352,7 @@ try:
         )
 except Mt5RuntimeError as e:
     print(f"MT5 Error: {e}")
-    print(f"Error code: {e.error_code}")
-    print(f"Description: {e.description}")
+    print("Inspect the exception message for the MT5 status details.")
 ```
 
 ## Limitations

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -99,13 +99,6 @@ class Mt5DataClient(Mt5Client):
         """Return a one-row DataFrame from a dictionary."""
         return pd.DataFrame([data])
 
-    @staticmethod
-    def _unwrap_password(password: str | SecretStr | None) -> str | None:
-        """Return a plain password string only at the MT5 call boundary."""
-        if isinstance(password, SecretStr):
-            return password.get_secret_value()
-        return password
-
     def initialize_and_login_mt5(
         self,
         path: str | None = None,

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -8,7 +8,7 @@ from datetime import datetime  # noqa: TC003
 from typing import Any, Self, cast
 
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 from .mt5 import Mt5Client, Mt5RuntimeError
 from .utils import (
@@ -27,11 +27,25 @@ class Mt5Config(BaseModel):
         default=None, description="Path to MetaTrader5 terminal EXE file"
     )
     login: int | None = Field(default=None, description="Trading account login")
-    password: str | None = Field(default=None, description="Trading account password")
+    password: str | SecretStr | None = Field(
+        default=None, description="Trading account password"
+    )
     server: str | None = Field(default=None, description="Trading server name")
     timeout: int | None = Field(
         default=None, description="Connection timeout in milliseconds"
     )
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def _coerce_password(cls, value: str | SecretStr | None) -> SecretStr | None:
+        """Normalize password inputs to SecretStr for masked serialization.
+
+        Returns:
+            Password value stored as SecretStr when provided.
+        """
+        if value is None or isinstance(value, SecretStr):
+            return value
+        return SecretStr(value)
 
 
 class Mt5DataClient(Mt5Client):
@@ -85,17 +99,22 @@ class Mt5DataClient(Mt5Client):
         """Return a one-row DataFrame from a dictionary."""
         return pd.DataFrame([data])
 
+    @staticmethod
+    def _unwrap_password(password: str | SecretStr | None) -> str | None:
+        """Return a plain password string only at the MT5 call boundary."""
+        if isinstance(password, SecretStr):
+            return password.get_secret_value()
+        return password
+
     def initialize_and_login_mt5(
         self,
         path: str | None = None,
         login: int | None = None,
-        password: str | None = None,
+        password: str | SecretStr | None = None,
         server: str | None = None,
         timeout: int | None = None,
     ) -> None:
-        """Initialize MetaTrader5 connection with retry logic.
-
-        This method overrides the base class to add retry logic and use config values.
+        """Initialize an MT5 connection with config-aware retry and login support.
 
         Args:
             path: Path to terminal EXE file (overrides config).
@@ -109,7 +128,9 @@ class Mt5DataClient(Mt5Client):
         """
         path = path or self.config.path
         login_value = login if login is not None else self.config.login
-        password_value = password if password is not None else self.config.password
+        password_value = self._unwrap_password(
+            password if password is not None else self.config.password
+        )
         server_value = server if server is not None else self.config.server
         timeout_value = timeout if timeout is not None else self.config.timeout
         for i in range(1 + max(0, self.retry_count)):

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -10,7 +10,7 @@ from functools import wraps
 from types import ModuleType  # noqa: TC003
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -105,12 +105,19 @@ class Mt5Client(BaseModel):
         """Context manager exit."""
         self.shutdown()
 
+    @staticmethod
+    def _unwrap_password(password: str | SecretStr | None) -> str | None:
+        """Return a plain password string only at the MT5 call boundary."""
+        if isinstance(password, SecretStr):
+            return password.get_secret_value()
+        return password
+
     @_log_mt5_last_status_code
     def initialize(
         self,
         path: str | None = None,
         login: int | None = None,
-        password: str | None = None,
+        password: str | SecretStr | None = None,
         server: str | None = None,
         timeout: int | None = None,
     ) -> bool:
@@ -130,7 +137,7 @@ class Mt5Client(BaseModel):
             k: v
             for k, v in {
                 "login": login,
-                "password": password,
+                "password": self._unwrap_password(password),
                 "server": server,
                 "timeout": timeout,
             }.items()
@@ -157,7 +164,7 @@ class Mt5Client(BaseModel):
     def login(
         self,
         login: int,
-        password: str | None = None,
+        password: str | SecretStr | None = None,
         server: str | None = None,
         timeout: int | None = None,
     ) -> bool:
@@ -179,7 +186,7 @@ class Mt5Client(BaseModel):
             **{
                 k: v
                 for k, v in {
-                    "password": password,
+                    "password": self._unwrap_password(password),
                     "server": server,
                     "timeout": timeout,
                 }.items()

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple, cast
 import numpy as np
 import pandas as pd
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 from pytest_mock import MockerFixture
 
 from pdmt5.dataframe import Mt5Config, Mt5DataClient
@@ -55,6 +55,7 @@ _MT5_METHODS = (
     "market_book_release",
     "market_book_get",
 )
+_MASKED_SECRET = "*" * 10
 
 
 @pytest.fixture(autouse=True)
@@ -632,7 +633,8 @@ class TestMt5Config:
             timeout=30000,
         )
         assert config.login == 123456
-        assert config.password == "secret"  # noqa: S105
+        assert isinstance(config.password, SecretStr)
+        assert config.password.get_secret_value() == "secret"
         assert config.server == "Demo-Server"
         assert config.timeout == 30000
 
@@ -641,6 +643,25 @@ class TestMt5Config:
         config = Mt5Config()
         with pytest.raises(ValidationError):
             config.login = 123456
+
+    def test_config_masks_password_in_string_representations(self) -> None:
+        """Test SecretStr masks the password in printable config output."""
+        config = Mt5Config(password="secret")
+        dumped_password = config.model_dump()["password"]
+
+        assert "secret" not in repr(config)
+        assert "secret" not in str(config)
+        assert "secret" not in repr(config.model_dump())
+        assert isinstance(dumped_password, SecretStr)
+        assert str(dumped_password) == _MASKED_SECRET
+        assert config.model_dump(mode="json")["password"] == _MASKED_SECRET
+
+    def test_config_accepts_secretstr_input(self) -> None:
+        """Test SecretStr inputs are preserved without exposing the secret."""
+        config = Mt5Config(password=SecretStr("secret"))
+
+        assert isinstance(config.password, SecretStr)
+        assert config.password.get_secret_value() == "secret"
 
 
 class TestMt5DataClient:
@@ -666,7 +687,30 @@ class TestMt5DataClient:
         client = Mt5DataClient(mt5=mock_mt5_import, config=config)
         assert client.config == config
         assert client.config.login == 123456
+        assert isinstance(client.config.password, SecretStr)
+        assert client.config.password.get_secret_value() == "test"
         assert client.config.timeout == 30000
+
+    def test_client_masks_nested_password_in_dumps(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test nested client config dumps do not expose a literal password."""
+        assert mock_mt5_import is not None
+        client = Mt5DataClient(
+            mt5=mock_mt5_import,
+            config=Mt5Config(password="secret"),
+        )
+        dumped_password = client.model_dump()["config"]["password"]
+
+        assert "secret" not in repr(client)
+        assert "secret" not in str(client)
+        assert "secret" not in repr(client.model_dump())
+        assert isinstance(dumped_password, SecretStr)
+        assert str(dumped_password) == _MASKED_SECRET
+        assert (
+            client.model_dump(mode="json", exclude={"mt5"})["config"]["password"]
+            == _MASKED_SECRET
+        )
 
     def test_mt5_module_default_factory(self, mocker: MockerFixture) -> None:
         """Test initialization with default mt5 module factory."""
@@ -859,6 +903,35 @@ class TestMt5DataClient:
             client.initialize_and_login_mt5()
 
         mock_mt5_import.shutdown.assert_called_once()
+
+    def test_initialize_and_login_unwraps_secret_password_override(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test SecretStr overrides are unwrapped before MT5 calls."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        mock_mt5_import.login.return_value = True
+        client = Mt5DataClient(mt5=mock_mt5_import, retry_count=0)
+
+        client.initialize_and_login_mt5(
+            login=123456,
+            password=SecretStr("secret"),
+            server="Demo",
+            timeout=60000,
+        )
+
+        mock_mt5_import.initialize.assert_called_once_with(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        mock_mt5_import.login.assert_called_once_with(
+            123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
 
     @pytest.mark.parametrize(
         ("client_method", "mt5_method"),

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -624,11 +624,19 @@ class TestMt5Config:
         assert config.server is None
         assert config.timeout is None
 
-    def test_custom_config(self) -> None:
-        """Test custom configuration."""
+    @pytest.mark.parametrize(
+        "password_input",
+        [
+            "secret",
+            SecretStr("secret"),
+        ],
+        ids=["str-password", "secretstr-password"],
+    )
+    def test_config_password_coercion(self, password_input: str | SecretStr) -> None:
+        """Test Mt5Config coerces password inputs to SecretStr."""
         config = Mt5Config(
             login=123456,
-            password="secret",
+            password=password_input,
             server="Demo-Server",
             timeout=30000,
         )
@@ -655,13 +663,6 @@ class TestMt5Config:
         assert isinstance(dumped_password, SecretStr)
         assert str(dumped_password) == _MASKED_SECRET
         assert config.model_dump(mode="json")["password"] == _MASKED_SECRET
-
-    def test_config_accepts_secretstr_input(self) -> None:
-        """Test SecretStr inputs are preserved without exposing the secret."""
-        config = Mt5Config(password=SecretStr("secret"))
-
-        assert isinstance(config.password, SecretStr)
-        assert config.password.get_secret_value() == "secret"
 
 
 class TestMt5DataClient:

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -74,70 +74,63 @@ class TestMt5Client:
         assert client._is_initialized is True  # type: ignore[reportPrivateUsage]
         mock_mt5.initialize.assert_called_once_with()
 
-    def test_initialize_with_parameters(
-        self, client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize(
+        ("path", "password_input"),
+        [
+            ("/path/to/mt5.exe", "secret"),
+            ("/path/to/mt5.exe", SecretStr("secret")),
+            (None, "secret"),
+            (None, SecretStr("secret")),
+        ],
+        ids=[
+            "with-path-str-password",
+            "with-path-secretstr-password",
+            "without-path-str-password",
+            "without-path-secretstr-password",
+        ],
+    )
+    def test_initialize_with_password_types(
+        self,
+        client: Mt5Client,
+        mock_mt5: Mock,
+        path: str | None,
+        password_input: str | SecretStr,
     ) -> None:
-        """Test initialization with parameters."""
+        """Test initialization unwraps passwords of different types before MT5 calls."""
         mock_mt5.initialize.return_value = True
 
-        result = client.initialize(
-            path="/path/to/mt5.exe",
-            login=12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
+        if path:
+            result = client.initialize(
+                path=path,
+                login=12345,
+                password=password_input,
+                server="Demo",
+                timeout=60000,
+            )
+        else:
+            result = client.initialize(
+                login=12345,
+                password=password_input,
+                server="Demo",
+                timeout=60000,
+            )
 
         assert result is True
-        mock_mt5.initialize.assert_called_once_with(
-            "/path/to/mt5.exe",
-            login=12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
-
-    def test_initialize_with_credentials_without_path(
-        self, client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test initialization passes credentials even without a path."""
-        mock_mt5.initialize.return_value = True
-
-        result = client.initialize(
-            login=12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
-
-        assert result is True
-        mock_mt5.initialize.assert_called_once_with(
-            login=12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
-
-    def test_initialize_unwraps_secret_password(
-        self, client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test initialization unwraps SecretStr passwords before MT5 calls."""
-        mock_mt5.initialize.return_value = True
-
-        result = client.initialize(
-            login=12345,
-            password=SecretStr("secret"),
-            server="Demo",
-            timeout=60000,
-        )
-
-        assert result is True
-        mock_mt5.initialize.assert_called_once_with(
-            login=12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
+        if path:
+            mock_mt5.initialize.assert_called_once_with(
+                path,
+                login=12345,
+                password="secret",
+                server="Demo",
+                timeout=60000,
+            )
+        else:
+            mock_mt5.initialize.assert_called_once_with(
+                login=12345,
+                password="secret",
+                server="Demo",
+                timeout=60000,
+            )
 
     def test_initialize_failure(self, client: Mt5Client, mock_mt5: Mock) -> None:
         """Test initialization failure."""
@@ -176,18 +169,52 @@ class TestMt5Client:
         mock_mt5.initialize.assert_called_once()
         assert client._is_initialized is True  # type: ignore[reportPrivateUsage]
 
-    def test_login_success(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
-        """Test successful login."""
+    @pytest.mark.parametrize(
+        ("password_input", "timeout"),
+        [
+            ("secret", 60000),
+            (SecretStr("secret"), 60000),
+            ("secret", None),
+            (SecretStr("secret"), None),
+        ],
+        ids=[
+            "str-password-with-timeout",
+            "secretstr-password-with-timeout",
+            "str-password-without-timeout",
+            "secretstr-password-without-timeout",
+        ],
+    )
+    def test_login_with_password_types(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        password_input: str | SecretStr,
+        timeout: int | None,
+    ) -> None:
+        """Test login unwraps passwords of different types before MT5 calls."""
         mock_mt5.login.return_value = True
 
-        result = initialized_client.login(
-            login=12345, password="secret", server="Demo", timeout=60000
-        )
+        if timeout:
+            result = initialized_client.login(
+                login=12345,
+                password=password_input,
+                server="Demo",
+                timeout=timeout,
+            )
+        else:
+            result = initialized_client.login(
+                login=12345, password=password_input, server="Demo"
+            )
 
         assert result is True
-        mock_mt5.login.assert_called_once_with(
-            12345, password="secret", server="Demo", timeout=60000
-        )
+        if timeout:
+            mock_mt5.login.assert_called_once_with(
+                12345, password="secret", server="Demo", timeout=timeout
+            )
+        else:
+            mock_mt5.login.assert_called_once_with(
+                12345, password="secret", server="Demo"
+            )
 
     def test_login_failure(self, initialized_client: Mt5Client, mock_mt5: Mock) -> None:
         """Test login failure."""
@@ -196,27 +223,6 @@ class TestMt5Client:
         result = initialized_client.login(12345, "secret", "Demo")
 
         assert result is False
-
-    def test_login_unwraps_secret_password(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test login unwraps SecretStr passwords before MT5 calls."""
-        mock_mt5.login.return_value = True
-
-        result = initialized_client.login(
-            login=12345,
-            password=SecretStr("secret"),
-            server="Demo",
-            timeout=60000,
-        )
-
-        assert result is True
-        mock_mt5.login.assert_called_once_with(
-            12345,
-            password="secret",
-            server="Demo",
-            timeout=60000,
-        )
 
     def test_version(
         self,
@@ -852,16 +858,6 @@ class TestMt5Client:
         result = getattr(initialized_client, method_name)(**kwargs)
         assert result is not None
         getattr(mock_mt5, method_name).assert_called_with(**kwargs)
-
-    def test_login_without_timeout(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
-    ) -> None:
-        """Test login method without timeout parameter."""
-        mock_mt5.login.return_value = True
-
-        result = initialized_client.login(12345, "secret", "Demo")
-        assert result is True
-        mock_mt5.login.assert_called_with(12345, password="secret", server="Demo")
 
     def test_empty_market_book_get(
         self, initialized_client: Mt5Client, mock_mt5: Mock

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from pydantic import SecretStr
 
 from pdmt5.mt5 import Mt5Client, Mt5RuntimeError
 
@@ -117,6 +118,27 @@ class TestMt5Client:
             timeout=60000,
         )
 
+    def test_initialize_unwraps_secret_password(
+        self, client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test initialization unwraps SecretStr passwords before MT5 calls."""
+        mock_mt5.initialize.return_value = True
+
+        result = client.initialize(
+            login=12345,
+            password=SecretStr("secret"),
+            server="Demo",
+            timeout=60000,
+        )
+
+        assert result is True
+        mock_mt5.initialize.assert_called_once_with(
+            login=12345,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+
     def test_initialize_failure(self, client: Mt5Client, mock_mt5: Mock) -> None:
         """Test initialization failure."""
         mock_mt5.initialize.return_value = False
@@ -174,6 +196,27 @@ class TestMt5Client:
         result = initialized_client.login(12345, "secret", "Demo")
 
         assert result is False
+
+    def test_login_unwraps_secret_password(
+        self, initialized_client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test login unwraps SecretStr passwords before MT5 calls."""
+        mock_mt5.login.return_value = True
+
+        result = initialized_client.login(
+            login=12345,
+            password=SecretStr("secret"),
+            server="Demo",
+            timeout=60000,
+        )
+
+        assert result is True
+        mock_mt5.login.assert_called_once_with(
+            12345,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
 
     def test_version(
         self,


### PR DESCRIPTION
Closes #93
Closes #95

## Summary
- normalize `Mt5Config.password` to `pydantic.SecretStr` so `repr()`, `str()`, and model dumps mask MT5 passwords
- unwrap the real password only at the MT5 initialize/login boundary so runtime behavior is unchanged
- fix the stale `initialize_and_login_mt5` docstring
- update README error-handling guidance for the current `Mt5RuntimeError` API
- update the README coverage statement to the enforced 100% threshold
- remove stale `trading.py` / dry-run contributor guidance from `AGENTS.md` and `CLAUDE.md`

## Validation
- `uv run pytest --no-cov tests/test_dataframe.py -k 'Mt5Config or masks_nested_password or unwraps_secret_password_override or context_manager_uses_config_and_retries or initialize_and_login'`
- `.agents/skills/local-qa/scripts/qa.sh`

## Notes
- `CLAUDE.md` is a symlink to `AGENTS.md`, so the contributor-guide update applies to both.
