### PR TITLE
Fix initialization, filter, and timestamp-contract issues (#99-#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,29 @@ except Mt5RuntimeError as e:
     print("Inspect the exception message for the MT5 status details.")
 ```
 
+## Timestamps and Timezones
+
+MT5 epoch timestamps (`time`, `time_msc`, `time_setup`, etc.) are labels on the
+**trade server's wall clock** (typically UTC+2 or UTC+3), not true UTC. pdmt5
+converts them to **timezone-naive** `datetime64`/`Timestamp` values that
+preserve those labels:
+
+- Converted datetimes are naive and represent server time. Do **not** treat
+  them as UTC; comparing them against `datetime.now(UTC)` or persisting them
+  with a UTC label introduces a 2–3 hour bias.
+- `date_from`/`date_to` arguments (e.g. in `history_deals_get`,
+  `copy_rates_range`, `copy_ticks_range`) are compared against server-labeled
+  epochs by the MetaTrader5 API, so pass datetimes expressed in server time.
+- To skip the conversion and work with the raw epochs, pass
+  `skip_to_datetime=True` to the `*_as_dict`/`*_as_df` methods.
+
 ## Limitations
 
 - **Windows Only**: Due to MetaTrader5 API requirements
 - **MT5 Terminal Required**: The MetaTrader 5 terminal must be installed
 - **Single Thread**: MT5 API is not thread-safe
+- **Server-Time Timestamps**: Returned datetimes are timezone-naive server
+  time, not UTC (see [Timestamps and Timezones](#timestamps-and-timezones))
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ preserve those labels:
 - `date_from`/`date_to` arguments (e.g. in `history_deals_get`,
   `copy_rates_range`, `copy_ticks_range`) are compared against server-labeled
   epochs by the MetaTrader5 API, so pass datetimes expressed in server time.
+- The official MQL5 docs call these epochs "UTC" because no timezone shift is
+  applied to them, and they recommend `tzinfo=timezone.utc` so that the
+  MetaTrader5 package does not shift naive datetimes by your local timezone.
+  Both hold here: construct datetimes with `tzinfo=timezone.utc`, but choose
+  wall-clock values that follow the trade server's clock.
 - To skip the conversion and work with the raw epochs, pass
   `skip_to_datetime=True` to the `*_as_dict`/`*_as_df` methods.
 

--- a/docs/api/dataframe.md
+++ b/docs/api/dataframe.md
@@ -41,11 +41,9 @@ config = Mt5Config(login=123456, password="your_password", server="broker_server
 # Create client
 client = Mt5DataClient(mt5=mt5, config=config)
 
-# Use as context manager
+# Use as context manager: entering the block initializes the connection and
+# logs in with the config credentials automatically
 with client:
-    # Optional: login when credentials are provided
-    client.login(config.login, config.password, config.server)
-
     # Get account information
     account_df = client.account_info_as_df()
     print(account_df)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -56,17 +56,16 @@ from pdmt5 import (
 import MetaTrader5 as mt5
 from datetime import datetime
 
-# Low-level API access with Mt5Client
+# Low-level API access with Mt5Client (the context manager initializes on
+# entry and raises Mt5RuntimeError on failure)
 with Mt5Client(mt5=mt5) as client:
-    client.initialize()
     account = client.account_info()
     rates = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
-# Pandas-friendly interface with Mt5DataClient and configuration
+# Pandas-friendly interface with Mt5DataClient and configuration (the context
+# manager initializes and logs in with the config credentials automatically)
 config = Mt5Config(login=12345, password="pass", server="MetaQuotes-Demo")
 with Mt5DataClient(mt5=mt5, config=config) as client:
-    # Optional: login when credentials are provided
-    client.login(config.login, config.password, config.server)
     symbols_df = client.symbols_get_as_df()
     rates_df = client.copy_rates_from_as_df(
         "EURUSD", parse_timeframe("H1"), datetime.now(), 100

--- a/docs/api/mt5.md
+++ b/docs/api/mt5.md
@@ -35,44 +35,46 @@ from pdmt5.mt5 import Mt5Client
 # Create client
 client = Mt5Client(mt5=mt5)
 
-# Use as context manager
+# Use as context manager: entering the block initializes the connection
+# and raises Mt5RuntimeError if initialization fails
 with client:
-    # Initialize connection
-    success = client.initialize()
-    if success:
-        print("Connected to MetaTrader 5")
+    print("Connected to MetaTrader 5")
 
-        # Get version info
-        version = client.version()
-        print(f"MT5 Version: {version}")
+    # Get version info
+    version = client.version()
+    print(f"MT5 Version: {version}")
 
-        # Get account info
-        account = client.account_info()
-        print(f"Account: {account}")
+    # Get account info
+    account = client.account_info()
+    print(f"Account: {account}")
 ```
 
 ### Connection with Login
 
 ```python
 with client:
-    # Initialize with path
-    client.initialize(path="C:\\Program Files\\MetaTrader 5\\terminal64.exe")
-
-    # Login to specific account
+    # The context manager already initialized the connection;
+    # log in to a specific account
     success = client.login(
         login=12345, password="your_password", server="broker_server"
     )
 
     if success:
         print("Logged in successfully")
+
+# To initialize with custom arguments (e.g. a terminal path), call
+# initialize() explicitly instead of relying on the context manager entry
+client.initialize(path="C:\\Program Files\\MetaTrader 5\\terminal64.exe")
+try:
+    ...
+finally:
+    client.shutdown()
 ```
 
 ### Symbol Operations
 
 ```python
 with client:
-    client.initialize()
-
     # Get total number of symbols
     total = client.symbols_total()
     print(f"Total symbols: {total}")
@@ -100,8 +102,6 @@ from datetime import datetime
 import MetaTrader5 as mt5
 
 with client:
-    client.initialize()
-
     # Get OHLCV rates from specific date
     rates = client.copy_rates_from(
         symbol="EURUSD",
@@ -131,7 +131,6 @@ with client:
 
 ```python
 with client:
-    client.initialize()
     client.login(12345, "password", "server")
 
     # Get current positions
@@ -165,8 +164,6 @@ with client:
 from datetime import datetime
 
 with client:
-    client.initialize()
-
     # Get historical orders
     history_orders = client.history_orders_get(
         date_from=datetime(2024, 1, 1), date_to=datetime(2024, 1, 31)
@@ -185,8 +182,6 @@ with client:
 
 ```python
 with client:
-    client.initialize()
-
     # Subscribe to market depth
     success = client.market_book_add("EURUSD")
     if success:
@@ -214,9 +209,9 @@ try:
 finally:
     client.shutdown()
 
-# Context manager (recommended)
+# Context manager (recommended): initializes on entry, shuts down on exit,
+# and raises Mt5RuntimeError if initialization fails
 with Mt5Client(mt5=mt5) as client:
-    client.initialize()
     # Your trading operations
     account = client.account_info()
 ```
@@ -230,24 +225,27 @@ from pdmt5.mt5 import Mt5RuntimeError
 
 try:
     with client:
-        client.initialize()
         rates = client.copy_rates_from("INVALID", mt5.TIMEFRAME_H1, datetime.now(), 100)
 except Mt5RuntimeError as e:
     print(f"MetaTrader 5 error: {e}")
 ```
 
+Entering the context manager also raises `Mt5RuntimeError` when the terminal
+cannot be initialized, and invalid argument combinations (e.g. mutually
+exclusive filters) raise `ValueError`.
+
 ## Logging
 
-The client includes comprehensive logging for all operations:
+The client includes comprehensive logging for all operations. Operations are
+logged at INFO level, and non-OK MT5 status codes at WARNING level:
 
 ```python
 import logging
 
-# Enable debug logging to see all MT5 operations
-logging.basicConfig(level=logging.DEBUG)
+# Enable INFO logging to see all MT5 operations
+logging.basicConfig(level=logging.INFO)
 
-with client:
-    client.initialize()  # Will log initialization details
+with client:  # Entry logs the initialization details
     account = client.account_info()  # Will log account retrieval
 ```
 
@@ -308,10 +306,14 @@ with client:
 
 ## Best Practices
 
-1. **Always use context manager** for automatic connection management
+1. **Always use context manager** for automatic connection management -
+   entering the `with` block initializes the connection and raises
+   `Mt5RuntimeError` on failure
 2. **Handle errors gracefully** with try-except blocks
-3. **Initialize before operations** - call `initialize()` after creating the client
-4. **Use logging** to debug connection and operation issues
-5. **Check return values** - many methods return None on failure
+3. **Call `initialize()` explicitly only outside the context manager** - for
+   example to pass a terminal path; pair it with `shutdown()`
+4. **Use logging** (INFO level) to debug connection and operation issues
+5. **Expect exceptions on failure** - data accessors raise `Mt5RuntimeError`
+   when MT5 returns None, and conflicting filter arguments raise `ValueError`
 6. **Use appropriate timeframes** and date ranges for data requests
 7. **Subscribe/unsubscribe** to market book properly to avoid resource leaks

--- a/docs/api/mt5.md
+++ b/docs/api/mt5.md
@@ -218,7 +218,7 @@ with Mt5Client(mt5=mt5) as client:
 
 ## Error Handling
 
-All methods include proper error handling and raise `Mt5RuntimeError` with detailed information when operations fail:
+Data-retrieval and trading methods raise `Mt5RuntimeError` with detailed information when the terminal reports a failure (for example, a `None` response or a failed initialization):
 
 ```python
 from pdmt5.mt5 import Mt5RuntimeError

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -42,8 +42,8 @@ These utilities are primarily used internally by Mt5DataClient methods through d
 
 ```python
 # Example of how decorators are applied internally
-@detect_and_convert_time_to_datetime(skip_toggle="skip_to_datetime")
 @set_index_if_possible(index_parameters="index_keys")
+@detect_and_convert_time_to_datetime(skip_toggle="skip_to_datetime")
 def some_method(
     self,
     skip_to_datetime: bool = False,
@@ -52,6 +52,11 @@ def some_method(
     # Method implementation
     pass
 ```
+
+`set_index_if_possible` must stay the outermost decorator: time conversion only
+touches DataFrame _columns_, so the index has to be set after the conversion
+has run. Reversing the order would move the raw epoch column into the index
+before conversion, leaving an unconverted integer index.
 
 ## Time Conversion Rules
 
@@ -116,7 +121,7 @@ The utilities module follows these principles:
 
 ## Performance Considerations
 
-- Conversions only happen when requested
+- Conversions run by default; opt out per call with `skip_to_datetime=True`
 - Dictionary operations use shallow copies
 - DataFrame operations use efficient pandas methods
 - Decorators add minimal overhead

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -62,7 +62,7 @@ before conversion, leaving an unconverted integer index.
 
 The time conversion follows these rules:
 
-1. **Millisecond Timestamps**: Fields ending with `_msc` are converted using `pd.to_datetime(value, unit="ms")`
+1. **Millisecond Timestamps**: Fields starting with `time_` and ending with `_msc` are converted using `pd.to_datetime(value, unit="ms")`
 2. **Second Timestamps**: Fields named `time` or starting with `time_` are converted using `pd.to_datetime(value, unit="s")`
 3. **Automatic Detection**: Conversion happens automatically unless explicitly disabled
 4. **Server Time, Not UTC**: MT5 epochs are trade-server wall-clock labels (typically UTC+2 or UTC+3); the converted datetimes are timezone-naive and preserve server time — they are not UTC

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -60,6 +60,7 @@ The time conversion follows these rules:
 1. **Millisecond Timestamps**: Fields ending with `_msc` are converted using `pd.to_datetime(value, unit="ms")`
 2. **Second Timestamps**: Fields named `time` or starting with `time_` are converted using `pd.to_datetime(value, unit="s")`
 3. **Automatic Detection**: Conversion happens automatically unless explicitly disabled
+4. **Server Time, Not UTC**: MT5 epochs are trade-server wall-clock labels (typically UTC+2 or UTC+3); the converted datetimes are timezone-naive and preserve server time — they are not UTC
 
 ## DataFrame Index Setting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,18 +41,15 @@ config = Mt5Config(
     timeout=60000,
 )
 
-# Low-level API access with context manager
+# Low-level API access with context manager (initializes on entry)
 with Mt5Client() as client:
-    client.initialize()
-    client.login(config.login, config.password, config.server)
+    client.login(12345678, "your_password", "YourBroker-Server")
     account = client.account_info()
     rates = client.copy_rates_from("EURUSD", mt5.TIMEFRAME_H1, datetime.now(), 100)
 
-# Pandas-friendly interface with context-managed initialization
+# Pandas-friendly interface: entering the context manager initializes the
+# connection and logs in with the config credentials automatically
 with Mt5DataClient(config=config) as client:
-    # Optional: login when credentials are provided
-    client.login(config.login, config.password, config.server)
-
     # Get symbol information as DataFrame
     symbols_df = client.symbols_get_as_df()
     # Get OHLCV data as DataFrame

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,20 @@ timeframe = parse_timeframe("TIMEFRAME_H1")  # 16385
 tick_flags = parse_copy_ticks("ALL")  # -1
 ```
 
+## Timestamps and Timezones
+
+MT5 epoch timestamps are labels on the **trade server's wall clock** (typically
+UTC+2 or UTC+3), not true UTC. pdmt5 converts them to **timezone-naive**
+`datetime64`/`Timestamp` values that preserve those labels:
+
+- Converted datetimes are naive and represent server time — do **not** treat
+  them as UTC.
+- `date_from`/`date_to` arguments (e.g. in `history_deals_get`,
+  `copy_rates_range`, `copy_ticks_range`) are compared against server-labeled
+  epochs by the MetaTrader5 API, so pass datetimes expressed in server time.
+- To work with the raw epochs instead, pass `skip_to_datetime=True` to the
+  `*_as_dict`/`*_as_df` methods.
+
 ## Requirements
 
 - Python 3.11+

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -418,7 +418,7 @@ class Mt5DataClient(Mt5Client):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date.
+            date_from: Start date in trade-server time (not UTC).
             count: Number of rates to retrieve.
             skip_to_datetime: Whether to skip converting time to datetime.
 
@@ -452,7 +452,7 @@ class Mt5DataClient(Mt5Client):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date.
+            date_from: Start date in trade-server time (not UTC).
             count: Number of rates to retrieve.
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
@@ -549,8 +549,8 @@ class Mt5DataClient(Mt5Client):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date.
-            date_to: End date.
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             skip_to_datetime: Whether to skip converting time to datetime.
 
         Returns:
@@ -583,8 +583,8 @@ class Mt5DataClient(Mt5Client):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date.
-            date_to: End date.
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
 
@@ -613,7 +613,7 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date.
+            date_from: Start date in trade-server time (not UTC).
             count: Number of ticks to retrieve.
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -647,7 +647,7 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date.
+            date_from: Start date in trade-server time (not UTC).
             count: Number of ticks to retrieve.
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -678,8 +678,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date.
-            date_to: End date.
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
 
@@ -712,8 +712,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date.
-            date_to: End date.
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
@@ -930,8 +930,10 @@ class Mt5DataClient(Mt5Client):
         """Get historical orders with optional filters as a list of dictionaries.
 
         Args:
-            date_from: Start date (required if not using ticket/position).
-            date_to: End date (required if not using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if
+                not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not
+                using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.
@@ -977,8 +979,10 @@ class Mt5DataClient(Mt5Client):
         """Get historical orders with optional filters as a data frame.
 
         Args:
-            date_from: Start date (required if not using ticket/position).
-            date_to: End date (required if not using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if
+                not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not
+                using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.
@@ -1016,8 +1020,10 @@ class Mt5DataClient(Mt5Client):
         """Get historical deals with optional filters as a list of dictionaries.
 
         Args:
-            date_from: Start date (required if not using ticket/position).
-            date_to: End date (required if not using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if
+                not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not
+                using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.
@@ -1063,8 +1069,10 @@ class Mt5DataClient(Mt5Client):
         """Get historical deals with optional filters as a data frame.
 
         Args:
-            date_from: Start date (required if not using ticket/position).
-            date_to: End date (required if not using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if
+                not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not
+                using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -742,9 +742,12 @@ class Mt5DataClient(Mt5Client):
         """Get active orders with optional filters as a list of dictionaries.
 
         Args:
-            symbol: Optional symbol filter.
-            group: Optional group filter.
-            ticket: Optional order ticket filter.
+            symbol: Optional symbol filter. Mutually exclusive with group and
+                ticket.
+            group: Optional group filter. Mutually exclusive with symbol and
+                ticket.
+            ticket: Optional order ticket filter. Mutually exclusive with
+                symbol and group.
             skip_to_datetime: Whether to skip converting time to datetime.
 
         Returns:
@@ -767,9 +770,12 @@ class Mt5DataClient(Mt5Client):
         """Get active orders with optional filters as a data frame.
 
         Args:
-            symbol: Optional symbol filter.
-            group: Optional group filter.
-            ticket: Optional order ticket filter.
+            symbol: Optional symbol filter. Mutually exclusive with group and
+                ticket.
+            group: Optional group filter. Mutually exclusive with symbol and
+                ticket.
+            ticket: Optional order ticket filter. Mutually exclusive with
+                symbol and group.
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
 
@@ -860,9 +866,12 @@ class Mt5DataClient(Mt5Client):
         """Get open positions with optional filters as a list of dictionaries.
 
         Args:
-            symbol: Optional symbol filter.
-            group: Optional group filter.
-            ticket: Optional position ticket filter.
+            symbol: Optional symbol filter. Mutually exclusive with group and
+                ticket.
+            group: Optional group filter. Mutually exclusive with symbol and
+                ticket.
+            ticket: Optional position ticket filter. Mutually exclusive with
+                symbol and group.
             skip_to_datetime: Whether to skip converting time to datetime.
 
         Returns:
@@ -886,9 +895,12 @@ class Mt5DataClient(Mt5Client):
         """Get open positions with optional filters as a data frame.
 
         Args:
-            symbol: Optional symbol filter.
-            group: Optional group filter.
-            ticket: Optional position ticket filter.
+            symbol: Optional symbol filter. Mutually exclusive with group and
+                ticket.
+            group: Optional group filter. Mutually exclusive with symbol and
+                ticket.
+            ticket: Optional position ticket filter. Mutually exclusive with
+                symbol and group.
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
 
@@ -920,8 +932,9 @@ class Mt5DataClient(Mt5Client):
         Args:
             date_from: Start date (required if not using ticket/position).
             date_to: End date (required if not using ticket/position).
-            group: Optional group filter.
-            symbol: Optional symbol filter.
+            group: Optional group filter. Mutually exclusive with symbol.
+            symbol: Optional symbol filter matching the symbol name exactly.
+                Mutually exclusive with group.
             ticket: Get orders by ticket.
             position: Get orders by position.
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -934,8 +947,10 @@ class Mt5DataClient(Mt5Client):
             date_to=date_to,
             ticket=ticket,
             position=position,
+            group=group,
+            symbol=symbol,
         )
-        return self._as_dicts(
+        dicts = self._as_dicts(
             self.history_orders_get(
                 date_from=date_from,
                 date_to=date_to,
@@ -944,6 +959,7 @@ class Mt5DataClient(Mt5Client):
                 position=position,
             )
         )
+        return [d for d in dicts if d["symbol"] == symbol] if symbol else dicts
 
     @set_index_if_possible(index_parameters="index_keys")
     @detect_and_convert_time_to_datetime(skip_toggle="skip_to_datetime")
@@ -963,8 +979,9 @@ class Mt5DataClient(Mt5Client):
         Args:
             date_from: Start date (required if not using ticket/position).
             date_to: End date (required if not using ticket/position).
-            group: Optional group filter.
-            symbol: Optional symbol filter.
+            group: Optional group filter. Mutually exclusive with symbol.
+            symbol: Optional symbol filter matching the symbol name exactly.
+                Mutually exclusive with group.
             ticket: Get orders by ticket.
             position: Get orders by position.
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -1001,8 +1018,9 @@ class Mt5DataClient(Mt5Client):
         Args:
             date_from: Start date (required if not using ticket/position).
             date_to: End date (required if not using ticket/position).
-            group: Optional group filter.
-            symbol: Optional symbol filter.
+            group: Optional group filter. Mutually exclusive with symbol.
+            symbol: Optional symbol filter matching the symbol name exactly.
+                Mutually exclusive with group.
             ticket: Get deals by order ticket.
             position: Get deals by position ticket.
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -1015,8 +1033,10 @@ class Mt5DataClient(Mt5Client):
             date_to=date_to,
             ticket=ticket,
             position=position,
+            group=group,
+            symbol=symbol,
         )
-        return self._as_dicts(
+        dicts = self._as_dicts(
             self.history_deals_get(
                 date_from=date_from,
                 date_to=date_to,
@@ -1025,6 +1045,7 @@ class Mt5DataClient(Mt5Client):
                 position=position,
             )
         )
+        return [d for d in dicts if d["symbol"] == symbol] if symbol else dicts
 
     @set_index_if_possible(index_parameters="index_keys")
     @detect_and_convert_time_to_datetime(skip_toggle="skip_to_datetime")
@@ -1044,8 +1065,9 @@ class Mt5DataClient(Mt5Client):
         Args:
             date_from: Start date (required if not using ticket/position).
             date_to: End date (required if not using ticket/position).
-            group: Optional group filter.
-            symbol: Optional symbol filter.
+            group: Optional group filter. Mutually exclusive with symbol.
+            symbol: Optional symbol filter matching the symbol name exactly.
+                Mutually exclusive with group.
             ticket: Get deals by order ticket.
             position: Get deals by position ticket.
             skip_to_datetime: Whether to skip converting time to datetime.
@@ -1072,6 +1094,8 @@ class Mt5DataClient(Mt5Client):
         date_to: datetime | None = None,
         ticket: int | None = None,
         position: int | None = None,
+        group: str | None = None,
+        symbol: str | None = None,
     ) -> None:
         """Validate input parameters for history retrieval methods.
 
@@ -1080,11 +1104,17 @@ class Mt5DataClient(Mt5Client):
             date_to: End date.
             ticket: Order ticket.
             position: Position ticket.
+            group: Group filter.
+            symbol: Symbol filter.
 
         Raises:
-            ValueError: If both date_from and date_to are not provided
-                when not using ticket or position.
+            ValueError: If both symbol and group are provided, or if both
+                date_from and date_to are not provided when not using ticket
+                or position.
         """
+        if symbol is not None and group is not None:
+            error_message = "symbol and group filters are mutually exclusive."
+            raise ValueError(error_message)
         if ticket is not None or position is not None:
             pass
         elif date_from is None or date_to is None:

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -126,6 +126,7 @@ class Mt5DataClient(Mt5Client):
         )
         server_value = server if server is not None else self.config.server
         timeout_value = timeout if timeout is not None else self.config.timeout
+        last_error_value: tuple[int, str] | None = None
         for i in range(1 + max(0, self.retry_count)):
             if i:
                 logger.warning(
@@ -141,6 +142,7 @@ class Mt5DataClient(Mt5Client):
                 server=server_value,
                 timeout=timeout_value,
             ):
+                last_error_value = self.last_error()
                 continue
             try:
                 if login_value is None or self.login(
@@ -153,10 +155,11 @@ class Mt5DataClient(Mt5Client):
             except Exception:
                 self.shutdown()
                 raise
+            last_error_value = self.last_error()
             self.shutdown()
         error_message = (
             f"MT5 initialize and login failed after {self.retry_count} retries:"
-            f" {self.last_error()}"
+            f" {last_error_value}"
         )
         raise Mt5RuntimeError(error_message)
 

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -1116,22 +1116,27 @@ class Mt5DataClient(Mt5Client):
             symbol: Symbol filter.
 
         Raises:
-            ValueError: If both symbol and group are provided, or if both
-                date_from and date_to are not provided when not using ticket
-                or position.
+            ValueError: If both symbol and group are provided, if symbol or
+                group is combined with ticket or position, or if the date
+                range is missing or invalid when not using ticket or position.
         """
         if symbol is not None and group is not None:
             error_message = "symbol and group filters are mutually exclusive."
             raise ValueError(error_message)
-        if ticket is not None or position is not None:
-            pass
-        elif date_from is None or date_to is None:
-            error_message = (
-                "Both date_from and date_to must be provided"
-                " if not using ticket or position."
-            )
-            raise ValueError(error_message)
-        else:
+        self._validate_history_filters(
+            date_from=date_from,
+            date_to=date_to,
+            ticket=ticket,
+            position=position,
+            group=group,
+            symbol=symbol,
+        )
+        if (
+            ticket is None
+            and position is None
+            and date_from is not None
+            and date_to is not None
+        ):
             self._validate_date_range(date_from=date_from, date_to=date_to)
 
     @staticmethod

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -93,7 +93,7 @@ class Mt5Client(BaseModel):
         Returns:
             Mt5Client: The client instance.
         """
-        self.initialize()
+        self._initialize_or_raise()
         return self
 
     def __exit__(
@@ -268,7 +268,12 @@ class Mt5Client(BaseModel):
         """
         self._initialize_if_needed()
         logger.info("Retrieving total number of symbols.")
-        return self.mt5.symbols_total()
+        response = self.mt5.symbols_total()
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="symbols_total",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def symbols_get(self, group: str | None = None) -> tuple[Any, ...]:
@@ -618,7 +623,12 @@ class Mt5Client(BaseModel):
         """
         self._initialize_if_needed()
         logger.info("Retrieving total number of active orders.")
-        return self.mt5.orders_total()
+        response = self.mt5.orders_total()
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="orders_total",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def orders_get(
@@ -791,7 +801,12 @@ class Mt5Client(BaseModel):
         """
         self._initialize_if_needed()
         logger.info("Retrieving total number of open positions.")
-        return self.mt5.positions_total()
+        response = self.mt5.positions_total()
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="positions_total",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def positions_get(
@@ -855,7 +870,13 @@ class Mt5Client(BaseModel):
             date_from,
             date_to,
         )
-        return self.mt5.history_orders_total(date_from, date_to)
+        response = self.mt5.history_orders_total(date_from, date_to)
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="history_orders_total",
+            context=f"date_from={date_from}, date_to={date_to}",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def history_orders_get(
@@ -932,7 +953,13 @@ class Mt5Client(BaseModel):
             date_from,
             date_to,
         )
-        return self.mt5.history_deals_total(date_from, date_to)
+        response = self.mt5.history_deals_total(date_from, date_to)
+        self._validate_mt5_response_is_not_none(
+            response=response,
+            operation="history_deals_total",
+            context=f"date_from={date_from}, date_to={date_to}",
+        )
+        return response
 
     @_log_mt5_last_status_code
     def history_deals_get(
@@ -991,7 +1018,17 @@ class Mt5Client(BaseModel):
     def _initialize_if_needed(self) -> None:
         """Ensure the MetaTrader5 client is initialized before performing operations."""
         if not self._is_initialized:
-            self.initialize()
+            self._initialize_or_raise()
+
+    def _initialize_or_raise(self) -> None:
+        """Initialize the MetaTrader5 client and raise on failure.
+
+        Raises:
+            Mt5RuntimeError: If initialization fails.
+        """
+        if not self.initialize():
+            error_message = f"MT5 initialize failed: last_error={self.mt5.last_error()}"
+            raise Mt5RuntimeError(error_message)
 
     def _validate_mt5_response_is_not_none(
         self,

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -438,7 +438,7 @@ class Mt5Client(BaseModel):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
             count: Number of bars to retrieve.
 
         Returns:
@@ -517,8 +517,8 @@ class Mt5Client(BaseModel):
         Args:
             symbol: Symbol name.
             timeframe: Timeframe constant.
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
 
         Returns:
             Array of rates or None.
@@ -554,7 +554,7 @@ class Mt5Client(BaseModel):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
             count: Number of ticks to retrieve.
             flags: Tick flags.
 
@@ -591,8 +591,8 @@ class Mt5Client(BaseModel):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
             flags: Tick flags.
 
         Returns:
@@ -863,8 +863,8 @@ class Mt5Client(BaseModel):
         """Get the number of orders in trading history within the specified interval.
 
         Args:
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
 
         Returns:
             Number of historical orders.
@@ -895,8 +895,8 @@ class Mt5Client(BaseModel):
         """Get orders from trading history with the ability to filter by ticket or position.
 
         Args:
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
             group: Group filter. Mutually exclusive with ticket and position.
             ticket: Order ticket filter. Mutually exclusive with other filters.
             position: Position ticket filter. Mutually exclusive with other
@@ -954,8 +954,8 @@ class Mt5Client(BaseModel):
         """Get the number of deals in trading history within the specified interval.
 
         Args:
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
 
         Returns:
             Number of historical deals.
@@ -986,8 +986,8 @@ class Mt5Client(BaseModel):
         """Get deals from trading history within the specified interval with the ability to filter by ticket or position.
 
         Args:
-            date_from: Start date or timestamp.
-            date_to: End date or timestamp.
+            date_from: Start date or timestamp in trade-server time (not UTC).
+            date_to: End date or timestamp in trade-server time (not UTC).
             group: Group filter. Mutually exclusive with ticket and position.
             ticket: Order ticket filter. Mutually exclusive with other filters.
             position: Position ticket filter. Mutually exclusive with other

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -67,6 +67,9 @@ class Mt5Client(BaseModel):
         ) -> R:
             try:
                 response = func(self, *args, **kwargs)
+            except ValueError:
+                # Invalid argument combinations are caller errors, not MT5 failures.
+                raise
             except Exception as e:
                 error_message = f"MT5 {func.__name__} failed with error: {e}"
                 raise Mt5RuntimeError(error_message) from e
@@ -640,13 +643,14 @@ class Mt5Client(BaseModel):
         """Get active orders with the ability to filter by symbol or ticket.
 
         Args:
-            symbol: Symbol name filter.
-            group: Group filter.
-            ticket: Order ticket filter.
+            symbol: Symbol name filter. Mutually exclusive with group and ticket.
+            group: Group filter. Mutually exclusive with symbol and ticket.
+            ticket: Order ticket filter. Mutually exclusive with symbol and group.
 
         Returns:
             Tuple of order info structures or None.
         """
+        self._validate_filters_are_exclusive(symbol=symbol, group=group, ticket=ticket)
         self._initialize_if_needed()
         if ticket is not None:
             logger.info("Retrieving order with ticket: %d", ticket)
@@ -818,13 +822,14 @@ class Mt5Client(BaseModel):
         """Get open positions with the ability to filter by symbol or ticket.
 
         Args:
-            symbol: Symbol name filter.
-            group: Group filter.
-            ticket: Position ticket filter.
+            symbol: Symbol name filter. Mutually exclusive with group and ticket.
+            group: Group filter. Mutually exclusive with symbol and ticket.
+            ticket: Position ticket filter. Mutually exclusive with symbol and group.
 
         Returns:
             Tuple of position info structures or None.
         """
+        self._validate_filters_are_exclusive(symbol=symbol, group=group, ticket=ticket)
         self._initialize_if_needed()
         if ticket is not None:
             logger.info("Retrieving position with ticket: %d", ticket)
@@ -892,13 +897,21 @@ class Mt5Client(BaseModel):
         Args:
             date_from: Start date or timestamp.
             date_to: End date or timestamp.
-            group: Group filter.
-            ticket: Order ticket filter.
-            position: Position ticket filter.
+            group: Group filter. Mutually exclusive with ticket and position.
+            ticket: Order ticket filter. Mutually exclusive with other filters.
+            position: Position ticket filter. Mutually exclusive with other
+                filters.
 
         Returns:
             Tuple of historical order info structures or None.
         """  # noqa: E501
+        self._validate_history_filters(
+            date_from=date_from,
+            date_to=date_to,
+            group=group,
+            ticket=ticket,
+            position=position,
+        )
         self._initialize_if_needed()
         if ticket is not None:
             logger.info("Retrieving order with ticket: %d", ticket)
@@ -975,13 +988,21 @@ class Mt5Client(BaseModel):
         Args:
             date_from: Start date or timestamp.
             date_to: End date or timestamp.
-            group: Group filter.
-            ticket: Order ticket filter.
-            position: Position ticket filter.
+            group: Group filter. Mutually exclusive with ticket and position.
+            ticket: Order ticket filter. Mutually exclusive with other filters.
+            position: Position ticket filter. Mutually exclusive with other
+                filters.
 
         Returns:
             Tuple of historical deal info structures or None.
         """  # noqa: E501
+        self._validate_history_filters(
+            date_from=date_from,
+            date_to=date_to,
+            group=group,
+            ticket=ticket,
+            position=position,
+        )
         self._initialize_if_needed()
         if ticket is not None:
             logger.info("Retrieving deal with ticket: %d", ticket)
@@ -1029,6 +1050,70 @@ class Mt5Client(BaseModel):
         if not self.initialize():
             error_message = f"MT5 initialize failed: last_error={self.mt5.last_error()}"
             raise Mt5RuntimeError(error_message)
+
+    @staticmethod
+    def _validate_filters_are_exclusive(**filters: Any) -> None:
+        """Validate that at most one of the given filters is provided.
+
+        Args:
+            **filters: Filter names mapped to their values.
+
+        Raises:
+            ValueError: If more than one filter is not None.
+        """
+        provided = [k for k, v in filters.items() if v is not None]
+        if len(provided) > 1:
+            error_message = (
+                f"Mutually exclusive filters provided: {', '.join(provided)}."
+                " Use only one of them."
+            )
+            raise ValueError(error_message)
+
+    @staticmethod
+    def _validate_history_filters(
+        date_from: datetime | int | None,
+        date_to: datetime | int | None,
+        group: str | None,
+        ticket: int | None,
+        position: int | None,
+    ) -> None:
+        """Validate that history filters are not combined ambiguously.
+
+        Valid combinations are a ticket alone, a position alone, or a date
+        range with an optional group.
+
+        Args:
+            date_from: Start date or timestamp.
+            date_to: End date or timestamp.
+            group: Group filter.
+            ticket: Ticket filter.
+            position: Position filter.
+
+        Raises:
+            ValueError: If ticket or position is combined with another filter.
+        """
+        id_filters = [
+            k
+            for k, v in {"ticket": ticket, "position": position}.items()
+            if v is not None
+        ]
+        range_filters = [
+            k
+            for k, v in {
+                "date_from": date_from,
+                "date_to": date_to,
+                "group": group,
+            }.items()
+            if v is not None
+        ]
+        if len(id_filters) > 1 or (id_filters and range_filters):
+            error_message = (
+                "Mutually exclusive filters provided:"
+                f" {', '.join([*id_filters, *range_filters])}."
+                " Use a ticket alone, a position alone,"
+                " or a date range with an optional group."
+            )
+            raise ValueError(error_message)
 
     def _validate_mt5_response_is_not_none(
         self,

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -70,6 +70,9 @@ class Mt5Client(BaseModel):
             except ValueError:
                 # Invalid argument combinations are caller errors, not MT5 failures.
                 raise
+            except Mt5RuntimeError:
+                # Already-classified MT5 failures must not be wrapped again.
+                raise
             except Exception as e:
                 error_message = f"MT5 {func.__name__} failed with error: {e}"
                 raise Mt5RuntimeError(error_message) from e
@@ -236,7 +239,7 @@ class Mt5Client(BaseModel):
         """Get info on the current trading account.
 
         Returns:
-            AccountInfo structure or None.
+            AccountInfo structure.
         """
         self._initialize_if_needed()
         logger.info("Retrieving account information.")
@@ -251,7 +254,7 @@ class Mt5Client(BaseModel):
         """Get the connected MetaTrader 5 client terminal status and settings.
 
         Returns:
-            TerminalInfo structure or None.
+            TerminalInfo structure.
         """
         self._initialize_if_needed()
         logger.info("Retrieving terminal information.")
@@ -286,7 +289,7 @@ class Mt5Client(BaseModel):
             group: Symbol group filter.
 
         Returns:
-            Tuple of symbol info structures or None.
+            Tuple of symbol info structures.
         """
         self._initialize_if_needed()
         if group is not None:
@@ -312,7 +315,7 @@ class Mt5Client(BaseModel):
             symbol: Symbol name.
 
         Returns:
-            Symbol info structure or None.
+            Symbol info structure.
         """
         self._initialize_if_needed()
         logger.info("Retrieving information for symbol: %s", symbol)
@@ -332,7 +335,7 @@ class Mt5Client(BaseModel):
             symbol: Symbol name.
 
         Returns:
-            Tick info structure or None.
+            Tick info structure.
         """
         self._initialize_if_needed()
         logger.info("Retrieving last tick for symbol: %s", symbol)
@@ -393,7 +396,7 @@ class Mt5Client(BaseModel):
             symbol: Symbol name.
 
         Returns:
-            Tuple of BookInfo structures or None.
+            Tuple of BookInfo structures.
         """  # noqa: E501
         self._initialize_if_needed()
         logger.info("Retrieving market book for symbol: %s", symbol)
@@ -442,7 +445,7 @@ class Mt5Client(BaseModel):
             count: Number of bars to retrieve.
 
         Returns:
-            Array of rates or None.
+            Array of rates.
         """
         self._initialize_if_needed()
         logger.info(
@@ -480,7 +483,7 @@ class Mt5Client(BaseModel):
             count: Number of bars to retrieve.
 
         Returns:
-            Array of rates or None.
+            Array of rates.
         """
         self._initialize_if_needed()
         logger.info(
@@ -521,7 +524,7 @@ class Mt5Client(BaseModel):
             date_to: End date or timestamp in trade-server time (not UTC).
 
         Returns:
-            Array of rates or None.
+            Array of rates.
         """
         self._initialize_if_needed()
         logger.info(
@@ -559,7 +562,7 @@ class Mt5Client(BaseModel):
             flags: Tick flags.
 
         Returns:
-            Array of ticks or None.
+            Array of ticks.
         """
         self._initialize_if_needed()
         logger.info(
@@ -596,7 +599,7 @@ class Mt5Client(BaseModel):
             flags: Tick flags.
 
         Returns:
-            Array of ticks or None.
+            Array of ticks.
         """
         self._initialize_if_needed()
         logger.info(
@@ -640,7 +643,7 @@ class Mt5Client(BaseModel):
         group: str | None = None,
         ticket: int | None = None,
     ) -> tuple[Any, ...]:
-        """Get active orders with the ability to filter by symbol or ticket.
+        """Get active orders with the ability to filter by symbol, group, or ticket.
 
         Args:
             symbol: Symbol name filter. Mutually exclusive with group and ticket.
@@ -648,7 +651,7 @@ class Mt5Client(BaseModel):
             ticket: Order ticket filter. Mutually exclusive with symbol and group.
 
         Returns:
-            Tuple of order info structures or None.
+            Tuple of order info structures.
         """
         self._validate_filters_are_exclusive(symbol=symbol, group=group, ticket=ticket)
         self._initialize_if_needed()
@@ -692,7 +695,7 @@ class Mt5Client(BaseModel):
             price: Open price.
 
         Returns:
-            Required margin amount or None.
+            Required margin amount.
         """  # noqa: E501
         self._initialize_if_needed()
         logger.info(
@@ -729,7 +732,7 @@ class Mt5Client(BaseModel):
             price_close: Close price.
 
         Returns:
-            Calculated profit or None.
+            Calculated profit.
         """
         self._initialize_if_needed()
         logger.info(
@@ -764,7 +767,7 @@ class Mt5Client(BaseModel):
             request: Trade request dictionary.
 
         Returns:
-            OrderCheckResult structure or None.
+            OrderCheckResult structure.
         """
         self._initialize_if_needed()
         logger.info("Checking order with request: %s", request)
@@ -784,7 +787,7 @@ class Mt5Client(BaseModel):
             request: Trade request dictionary.
 
         Returns:
-            OrderSendResult structure or None.
+            OrderSendResult structure.
         """  # noqa: E501
         self._initialize_if_needed()
         logger.info("Sending order with request: %s", request)
@@ -819,7 +822,7 @@ class Mt5Client(BaseModel):
         group: str | None = None,
         ticket: int | None = None,
     ) -> tuple[Any, ...]:
-        """Get open positions with the ability to filter by symbol or ticket.
+        """Get open positions with the ability to filter by symbol, group, or ticket.
 
         Args:
             symbol: Symbol name filter. Mutually exclusive with group and ticket.
@@ -827,7 +830,7 @@ class Mt5Client(BaseModel):
             ticket: Position ticket filter. Mutually exclusive with symbol and group.
 
         Returns:
-            Tuple of position info structures or None.
+            Tuple of position info structures.
         """
         self._validate_filters_are_exclusive(symbol=symbol, group=group, ticket=ticket)
         self._initialize_if_needed()
@@ -892,7 +895,7 @@ class Mt5Client(BaseModel):
         ticket: int | None = None,
         position: int | None = None,
     ) -> tuple[Any, ...]:
-        """Get orders from trading history with the ability to filter by ticket or position.
+        """Get orders from trading history with the ability to filter by ticket, position, or group.
 
         Args:
             date_from: Start date or timestamp in trade-server time (not UTC).
@@ -903,7 +906,7 @@ class Mt5Client(BaseModel):
                 filters.
 
         Returns:
-            Tuple of historical order info structures or None.
+            Tuple of historical order info structures.
         """  # noqa: E501
         self._validate_history_filters(
             date_from=date_from,
@@ -983,7 +986,7 @@ class Mt5Client(BaseModel):
         ticket: int | None = None,
         position: int | None = None,
     ) -> tuple[Any, ...]:
-        """Get deals from trading history within the specified interval with the ability to filter by ticket or position.
+        """Get deals from trading history within the specified interval with the ability to filter by ticket, position, or group.
 
         Args:
             date_from: Start date or timestamp in trade-server time (not UTC).
@@ -994,7 +997,7 @@ class Mt5Client(BaseModel):
                 filters.
 
         Returns:
-            Tuple of historical deal info structures or None.
+            Tuple of historical deal info structures.
         """  # noqa: E501
         self._validate_history_filters(
             date_from=date_from,
@@ -1052,7 +1055,7 @@ class Mt5Client(BaseModel):
             raise Mt5RuntimeError(error_message)
 
     @staticmethod
-    def _validate_filters_are_exclusive(**filters: Any) -> None:
+    def _validate_filters_are_exclusive(**filters: str | int | None) -> None:
         """Validate that at most one of the given filters is provided.
 
         Args:
@@ -1073,24 +1076,26 @@ class Mt5Client(BaseModel):
     def _validate_history_filters(
         date_from: datetime | int | None,
         date_to: datetime | int | None,
-        group: str | None,
-        ticket: int | None,
-        position: int | None,
+        ticket: int | None = None,
+        position: int | None = None,
+        **name_filters: str | None,
     ) -> None:
         """Validate that history filters are not combined ambiguously.
 
         Valid combinations are a ticket alone, a position alone, or a date
-        range with an optional group.
+        range with an optional name filter such as group.
 
         Args:
             date_from: Start date or timestamp.
             date_to: End date or timestamp.
-            group: Group filter.
             ticket: Ticket filter.
             position: Position filter.
+            **name_filters: Name-based filters such as group.
 
         Raises:
-            ValueError: If ticket or position is combined with another filter.
+            ValueError: If ticket or position is combined with another filter,
+                or if either date is missing when no ticket or position is
+                provided.
         """
         id_filters = [
             k
@@ -1102,7 +1107,7 @@ class Mt5Client(BaseModel):
             for k, v in {
                 "date_from": date_from,
                 "date_to": date_to,
-                "group": group,
+                **name_filters,
             }.items()
             if v is not None
         ]
@@ -1111,7 +1116,13 @@ class Mt5Client(BaseModel):
                 "Mutually exclusive filters provided:"
                 f" {', '.join([*id_filters, *range_filters])}."
                 " Use a ticket alone, a position alone,"
-                " or a date range with an optional group."
+                " or a date range with an optional name filter."
+            )
+            raise ValueError(error_message)
+        if not id_filters and (date_from is None or date_to is None):
+            error_message = (
+                "Both date_from and date_to must be provided"
+                " if not using ticket or position."
             )
             raise ValueError(error_message)
 

--- a/pdmt5/utils.py
+++ b/pdmt5/utils.py
@@ -29,7 +29,8 @@ def detect_and_convert_time_to_datetime(
     datetimes are timezone-naive and represent server time, not UTC.
 
     Args:
-        skip_toggle: Name of the parameter to skip conversion if set to False.
+        skip_toggle: Name of the bound parameter that skips conversion when
+            its value is truthy.
 
     Returns:
         Decorator function.

--- a/pdmt5/utils.py
+++ b/pdmt5/utils.py
@@ -25,6 +25,9 @@ def detect_and_convert_time_to_datetime(
     - list: converts time values in each dictionary item
     - DataFrame: converts time columns
 
+    MT5 epoch timestamps are trade-server wall-clock labels, so the converted
+    datetimes are timezone-naive and represent server time, not UTC.
+
     Args:
         skip_toggle: Name of the parameter to skip conversion if set to False.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.1.0"
+version = "1.1.1"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1526,6 +1526,73 @@ class TestMt5DataClient:
         )
 
     @pytest.mark.parametrize(
+        "client_method",
+        ["history_orders_get_as_dicts", "history_deals_get_as_dicts"],
+    )
+    def test_history_get_symbol_and_group_conflict(
+        self, mock_mt5_import: ModuleType | None, client_method: str
+    ) -> None:
+        """Test history getters reject combined symbol and group filters."""
+        assert mock_mt5_import is not None
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(
+            ValueError, match=r"symbol and group filters are mutually exclusive"
+        ):
+            getattr(client, client_method)(
+                date_from=datetime(2022, 1, 1, tzinfo=UTC),
+                date_to=datetime(2022, 1, 2, tzinfo=UTC),
+                symbol="EURUSD",
+                group="*USD*",
+            )
+
+    @pytest.mark.parametrize(
+        ("client_method", "mt5_method", "row_factory"),
+        [
+            pytest.param(
+                "history_orders_get_as_df",
+                "history_orders_get",
+                _build_history_order_row,
+                id="orders",
+            ),
+            pytest.param(
+                "history_deals_get_as_df",
+                "history_deals_get",
+                _build_history_deal_row,
+                id="deals",
+            ),
+        ],
+    )
+    def test_history_get_symbol_exact_match(
+        self,
+        mock_mt5_import: ModuleType | None,
+        client_method: str,
+        mt5_method: str,
+        row_factory: Callable[[int], Any],
+    ) -> None:
+        """Test symbol filter excludes broker-suffixed symbol variants."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        getattr(mock_mt5_import, mt5_method).return_value = [
+            row_factory(0),
+            row_factory(0)._replace(symbol="EURUSD.m"),
+        ]
+
+        client = create_initialized_client(mock_mt5_import)
+        df_result = getattr(client, client_method)(
+            date_from=datetime(2022, 1, 1, tzinfo=UTC),
+            date_to=datetime(2022, 1, 2, tzinfo=UTC),
+            symbol="EURUSD",
+        )
+
+        assert isinstance(df_result, pd.DataFrame)
+        assert df_result["symbol"].tolist() == ["EURUSD"]
+        getattr(mock_mt5_import, mt5_method).assert_called_once_with(
+            datetime(2022, 1, 1, tzinfo=UTC),
+            datetime(2022, 1, 2, tzinfo=UTC),
+            group="*EURUSD*",
+        )
+
+    @pytest.mark.parametrize(
         ("client_method", "mt5_method"),
         [
             pytest.param(

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -848,6 +848,41 @@ class TestMt5DataClient:
         assert mock_mt5_import.login.call_count == 2
         mock_mt5_import.shutdown.assert_called_once()
 
+    def test_initialize_and_login_reports_login_error_before_shutdown(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test the raised error embeds the login failure read before shutdown."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        mock_mt5_import.login.return_value = False
+
+        def last_error_side_effect() -> tuple[int, str]:
+            if mock_mt5_import.shutdown.called:
+                return (10004, "No IPC connection")
+            return (-6, "Terminal: Authorization failed")
+
+        mock_mt5_import.last_error.side_effect = last_error_side_effect
+        config = Mt5Config(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+        client = Mt5DataClient(
+            mt5=mock_mt5_import,
+            config=config,
+            retry_count=0,
+        )
+
+        pattern = (
+            r"MT5 initialize and login failed after 0 retries: "
+            r"\(-6, 'Terminal: Authorization failed'\)"
+        )
+        with pytest.raises(Mt5RuntimeError, match=pattern):
+            client.initialize_and_login_mt5()
+
+        mock_mt5_import.shutdown.assert_called_once()
+
     def test_initialize_and_login_shuts_down_after_login_exception(
         self, mock_mt5_import: ModuleType | None
     ) -> None:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -755,6 +755,23 @@ class TestMt5DataClient:
 
         mock_mt5_import.shutdown.assert_called_once()
 
+    def test_context_manager_init_failure(
+        self, mock_mt5_import: ModuleType | None
+    ) -> None:
+        """Test context manager raises Mt5RuntimeError when initialization fails."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = False
+        mock_mt5_import.last_error.return_value = (1, "Connection failed")
+
+        client = Mt5DataClient(mt5=mock_mt5_import, retry_count=0)
+        with (
+            pytest.raises(Mt5RuntimeError, match=r"MT5 initialize and login failed"),
+            client,
+        ):
+            pass
+
+        mock_mt5_import.shutdown.assert_not_called()
+
     def test_context_manager_uses_config_and_retries(
         self, mock_mt5_import: ModuleType | None
     ) -> None:
@@ -1370,7 +1387,7 @@ class TestMt5DataClient:
 
         client = create_initialized_client(mock_mt5_import)
 
-        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+        with pytest.raises(Mt5RuntimeError, match=r"^MT5 version returned None"):
             client.version()
 
     @pytest.mark.parametrize("enable", [True, False])
@@ -1527,7 +1544,12 @@ class TestMt5DataClient:
 
     @pytest.mark.parametrize(
         "client_method",
-        ["history_orders_get_as_dicts", "history_deals_get_as_dicts"],
+        [
+            "history_orders_get_as_dicts",
+            "history_deals_get_as_dicts",
+            "history_orders_get_as_df",
+            "history_deals_get_as_df",
+        ],
     )
     def test_history_get_symbol_and_group_conflict(
         self, mock_mt5_import: ModuleType | None, client_method: str
@@ -1546,19 +1568,69 @@ class TestMt5DataClient:
             )
 
     @pytest.mark.parametrize(
+        "client_method",
+        [
+            "history_orders_get_as_dicts",
+            "history_deals_get_as_dicts",
+            "history_orders_get_as_df",
+            "history_deals_get_as_df",
+        ],
+    )
+    def test_history_get_symbol_and_ticket_conflict(
+        self, mock_mt5_import: ModuleType | None, client_method: str
+    ) -> None:
+        """Test history getters reject symbol combined with ticket."""
+        assert mock_mt5_import is not None
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(
+            ValueError, match=r"Mutually exclusive filters provided: ticket, symbol"
+        ):
+            getattr(client, client_method)(symbol="EURUSD", ticket=12345)
+
+    @pytest.mark.parametrize(
+        "client_method",
+        [
+            "orders_get_as_dicts",
+            "positions_get_as_dicts",
+            "orders_get_as_df",
+            "positions_get_as_df",
+        ],
+    )
+    def test_orders_positions_get_conflicting_filters(
+        self, mock_mt5_import: ModuleType | None, client_method: str
+    ) -> None:
+        """Test orders/positions getters reject combined symbol and group filters."""
+        assert mock_mt5_import is not None
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(ValueError, match=r"Mutually exclusive filters provided"):
+            getattr(client, client_method)(symbol="EURUSD", group="*USD*")
+
+    @pytest.mark.parametrize(
         ("client_method", "mt5_method", "row_factory"),
         [
             pytest.param(
                 "history_orders_get_as_df",
                 "history_orders_get",
                 _build_history_order_row,
-                id="orders",
+                id="orders-df",
             ),
             pytest.param(
                 "history_deals_get_as_df",
                 "history_deals_get",
                 _build_history_deal_row,
-                id="deals",
+                id="deals-df",
+            ),
+            pytest.param(
+                "history_orders_get_as_dicts",
+                "history_orders_get",
+                _build_history_order_row,
+                id="orders-dicts",
+            ),
+            pytest.param(
+                "history_deals_get_as_dicts",
+                "history_deals_get",
+                _build_history_deal_row,
+                id="deals-dicts",
             ),
         ],
     )
@@ -1578,14 +1650,17 @@ class TestMt5DataClient:
         ]
 
         client = create_initialized_client(mock_mt5_import)
-        df_result = getattr(client, client_method)(
+        result = getattr(client, client_method)(
             date_from=datetime(2022, 1, 1, tzinfo=UTC),
             date_to=datetime(2022, 1, 2, tzinfo=UTC),
             symbol="EURUSD",
         )
 
-        assert isinstance(df_result, pd.DataFrame)
-        assert df_result["symbol"].tolist() == ["EURUSD"]
+        if isinstance(result, pd.DataFrame):
+            symbols = result["symbol"].tolist()
+        else:
+            symbols = [d["symbol"] for d in result]
+        assert symbols == ["EURUSD"]
         getattr(mock_mt5_import, mt5_method).assert_called_once_with(
             datetime(2022, 1, 1, tzinfo=UTC),
             datetime(2022, 1, 2, tzinfo=UTC),
@@ -2465,7 +2540,7 @@ class TestMt5DataClientCoverageMissing:
         mock_mt5_import.version.return_value = None
         client = create_initialized_client(mock_mt5_import)
 
-        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+        with pytest.raises(Mt5RuntimeError, match=r"^MT5 version returned None"):
             getattr(client, client_method)()
 
     def test_last_error_as_dict(self, mock_mt5_import: ModuleType) -> None:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1172,11 +1172,8 @@ class TestMt5DataClient:
         ("client_method", "mt5_method", "return_value"),
         [
             ("orders_total", "orders_total", 5),
-            ("orders_total", "orders_total", None),
             ("positions_total", "positions_total", 3),
-            ("positions_total", "positions_total", None),
             ("symbols_total", "symbols_total", 1000),
-            ("symbols_total", "symbols_total", None),
         ],
     )
     def test_total_methods(
@@ -1184,9 +1181,9 @@ class TestMt5DataClient:
         mock_mt5_import: ModuleType | None,
         client_method: str,
         mt5_method: str,
-        return_value: int | None,
+        return_value: int,
     ) -> None:
-        """Test total-returning methods with values and None."""
+        """Test total-returning methods with values."""
         assert mock_mt5_import is not None
         mock_mt5_import.initialize.return_value = True
         getattr(mock_mt5_import, mt5_method).return_value = return_value
@@ -1197,14 +1194,27 @@ class TestMt5DataClient:
         assert result == return_value
 
     @pytest.mark.parametrize(
+        "method_name", ["orders_total", "positions_total", "symbols_total"]
+    )
+    def test_total_methods_raise_on_none(
+        self, mock_mt5_import: ModuleType | None, method_name: str
+    ) -> None:
+        """Test total-returning methods raise Mt5RuntimeError on None."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        getattr(mock_mt5_import, method_name).return_value = None
+
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(Mt5RuntimeError, match=rf"MT5 {method_name} returned None"):
+            getattr(client, method_name)()
+
+    @pytest.mark.parametrize(
         ("client_method", "mt5_method", "return_value"),
         [
             ("history_orders_total", "history_orders_total", 10),
             ("history_orders_total", "history_orders_total", 0),
-            ("history_orders_total", "history_orders_total", None),
             ("history_deals_total", "history_deals_total", 15),
             ("history_deals_total", "history_deals_total", 0),
-            ("history_deals_total", "history_deals_total", None),
         ],
     )
     def test_history_totals_methods(
@@ -1212,7 +1222,7 @@ class TestMt5DataClient:
         mock_mt5_import: ModuleType | None,
         client_method: str,
         mt5_method: str,
-        return_value: int | None,
+        return_value: int,
     ) -> None:
         """Test history total methods with varied return values."""
         assert mock_mt5_import is not None
@@ -1226,6 +1236,24 @@ class TestMt5DataClient:
         )
 
         assert result == return_value
+
+    @pytest.mark.parametrize(
+        "method_name", ["history_orders_total", "history_deals_total"]
+    )
+    def test_history_totals_methods_raise_on_none(
+        self, mock_mt5_import: ModuleType | None, method_name: str
+    ) -> None:
+        """Test history total methods raise Mt5RuntimeError on None."""
+        assert mock_mt5_import is not None
+        mock_mt5_import.initialize.return_value = True
+        getattr(mock_mt5_import, method_name).return_value = None
+
+        client = create_initialized_client(mock_mt5_import)
+        with pytest.raises(Mt5RuntimeError, match=rf"MT5 {method_name} returned None"):
+            getattr(client, method_name)(
+                datetime(2022, 1, 1, tzinfo=UTC),
+                datetime(2022, 1, 2, tzinfo=UTC),
+            )
 
     @pytest.mark.parametrize(
         ("volume", "price", "last_error"),

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -879,6 +879,57 @@ class TestMt5Client:
         assert result is not None
         getattr(mock_mt5, method_name).assert_called_with(**kwargs)
 
+    @pytest.mark.parametrize("method_name", ["orders_get", "positions_get"])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"symbol": "EURUSD", "group": "*USD*"}, id="symbol-group"),
+            pytest.param({"symbol": "EURUSD", "ticket": 12345}, id="symbol-ticket"),
+            pytest.param({"group": "*USD*", "ticket": 12345}, id="group-ticket"),
+        ],
+    )
+    def test_get_methods_conflicting_filters(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Test orders_get and positions_get reject combined filters."""
+        with pytest.raises(ValueError, match=r"Mutually exclusive filters provided"):
+            getattr(initialized_client, method_name)(**kwargs)
+
+        getattr(mock_mt5, method_name).assert_not_called()
+
+    @pytest.mark.parametrize("method_name", ["history_orders_get", "history_deals_get"])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"ticket": 12345, "position": 54321}, id="ticket-position"),
+            pytest.param(
+                {
+                    "ticket": 12345,
+                    "date_from": datetime(2023, 1, 1, tzinfo=UTC),
+                    "date_to": datetime(2023, 1, 31, tzinfo=UTC),
+                },
+                id="ticket-dates",
+            ),
+            pytest.param({"position": 54321, "group": "*USD*"}, id="position-group"),
+        ],
+    )
+    def test_history_get_conflicting_filters(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Test history getters reject ticket/position combined with others."""
+        with pytest.raises(ValueError, match=r"Mutually exclusive filters provided"):
+            getattr(initialized_client, method_name)(**kwargs)
+
+        getattr(mock_mt5, method_name).assert_not_called()
+
     def test_empty_market_book_get(
         self, initialized_client: Mt5Client, mock_mt5: Mock
     ) -> None:

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -265,7 +265,7 @@ class TestMt5Client:
         """Test version method raises Mt5RuntimeError on None response."""
         mock_mt5.version.return_value = None
 
-        with pytest.raises(Mt5RuntimeError, match=r"MT5 version failed with error:"):
+        with pytest.raises(Mt5RuntimeError, match=r"^MT5 version returned None"):
             initialized_client.version()
 
     @pytest.mark.parametrize(
@@ -585,15 +585,37 @@ class TestMt5Client:
         assert len(result) == 1
         getattr(mock_mt5, method_name).assert_called_once_with(**kwargs)
 
-    def test_history_orders_get_missing_dates(
-        self, initialized_client: Mt5Client, mock_mt5: Mock
+    @pytest.mark.parametrize("method_name", ["history_orders_get", "history_deals_get"])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({}, id="no-dates"),
+            pytest.param(
+                {"date_from": datetime(2023, 1, 1, tzinfo=UTC)},
+                id="date_from-only",
+            ),
+            pytest.param(
+                {"date_to": datetime(2023, 1, 31, tzinfo=UTC)},
+                id="date_to-only",
+            ),
+            pytest.param({"group": "*USD*"}, id="group-without-dates"),
+        ],
+    )
+    def test_history_get_missing_dates(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        kwargs: dict[str, Any],
     ) -> None:
-        """Test history_orders_get without required dates."""
-        # With new implementation, calling without dates passes None, None to MT5
-        mock_mt5.history_orders_get.return_value = ()
-        result = initialized_client.history_orders_get()
-        assert result == ()
-        mock_mt5.history_orders_get.assert_called_once_with(None, None)
+        """Test history getters reject calls without a full date range."""
+        with pytest.raises(
+            ValueError,
+            match=r"Both date_from and date_to must be provided",
+        ):
+            getattr(initialized_client, method_name)(**kwargs)
+
+        getattr(mock_mt5, method_name).assert_not_called()
 
     @pytest.mark.parametrize(
         ("method_name", "args", "mt5_return_value"),

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -64,6 +64,28 @@ class TestMt5Client:
         mock_mt5.shutdown.assert_called_once()
         assert client._is_initialized is False  # type: ignore[reportPrivateUsage]
 
+    def test_context_manager_raises_on_initialize_failure(
+        self, client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test context manager raises Mt5RuntimeError when initialization fails."""
+        mock_mt5.initialize.return_value = False
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 initialize failed"), client:
+            pass
+
+        mock_mt5.shutdown.assert_not_called()
+
+    def test_initialize_if_needed_raises_on_failure(
+        self, client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test methods raise Mt5RuntimeError when auto-initialization fails."""
+        mock_mt5.initialize.return_value = False
+
+        with pytest.raises(Mt5RuntimeError, match=r"MT5 initialize failed"):
+            client.symbols_total()
+
+        mock_mt5.symbols_total.assert_not_called()
+
     def test_initialize_success(self, client: Mt5Client, mock_mt5: Mock) -> None:
         """Test successful initialization."""
         mock_mt5.initialize.return_value = True
@@ -663,26 +685,38 @@ class TestMt5Client:
             getattr(initialized_client, method_name)()
 
     @pytest.mark.parametrize(
-        "method_name", ["symbols_total", "orders_total", "positions_total"]
+        ("method_name", "args"),
+        [
+            ("symbols_total", ()),
+            ("orders_total", ()),
+            ("positions_total", ()),
+            (
+                "history_orders_total",
+                (
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                ),
+            ),
+            (
+                "history_deals_total",
+                (
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2023, 1, 31, tzinfo=UTC),
+                ),
+            ),
+        ],
     )
-    def test_total_methods_pass_through_none(
-        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
+    def test_total_methods_raise_on_none(
+        self,
+        initialized_client: Mt5Client,
+        mock_mt5: Mock,
+        method_name: str,
+        args: tuple[Any, ...],
     ) -> None:
-        """Test that total methods pass through None without raising."""
+        """Test that total methods raise Mt5RuntimeError when MT5 returns None."""
         getattr(mock_mt5, method_name).return_value = None
-        assert getattr(initialized_client, method_name)() is None
-
-    @pytest.mark.parametrize(
-        "method_name", ["history_orders_total", "history_deals_total"]
-    )
-    def test_history_total_methods_pass_through_none(
-        self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str
-    ) -> None:
-        """Test that history total methods pass through None without raising."""
-        date_from = datetime(2023, 1, 1, tzinfo=UTC)
-        date_to = datetime(2023, 1, 31, tzinfo=UTC)
-        getattr(mock_mt5, method_name).return_value = None
-        assert getattr(initialized_client, method_name)(date_from, date_to) is None
+        with pytest.raises(Mt5RuntimeError, match=rf"MT5 {method_name} returned None"):
+            getattr(initialized_client, method_name)(*args)
 
     @pytest.mark.parametrize("method_name", ["market_book_add", "market_book_release"])
     def test_market_book_add_release_pass_through_false(

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

Fixes five issues found while debugging downstream live-trading consumers:

- **#100** — `Mt5DataClient.initialize_and_login_mt5()` now captures `last_error()` immediately after a failed `initialize()`/`login()` (before `shutdown()` closes the IPC connection), so the raised `Mt5RuntimeError` reports the real login/authorization error instead of the post-shutdown status.
- **#101** — `Mt5Client.__enter__()` and `_initialize_if_needed()` now raise `Mt5RuntimeError` (with `last_error()` details) when `initialize()` returns `False`, matching `Mt5DataClient` behavior. The five `*_total` methods validate their responses with `_validate_mt5_response_is_not_none`, so they no longer return `None` despite `-> int`.
- **#102** — `orders_get`/`positions_get`/`history_orders_get`/`history_deals_get` raise `ValueError` when mutually exclusive filters are combined (previously they silently applied `ticket > group > symbol` precedence). The history `symbol` filter now post-filters rows on exact symbol equality after the `*{symbol}*` group-wildcard fetch, so broker-suffixed variants (`EURUSD.m`, `EURUSD.raw`) are no longer returned; combining `symbol` with `group` also raises instead of silently dropping `group`.
- **#99** (docs) — New "Timestamps and Timezones" sections in `README.md`, `docs/index.md`, and `docs/api/utils.md`, plus docstring notes: MT5 epochs are trade-server wall-clock labels (typically UTC+2/+3) and pdmt5's converted datetimes are timezone-naive server time, **not UTC**; `date_from`/`date_to` arguments are interpreted in server time by the MetaTrader5 API.
- **#103** (docs) — Fixed the reversed decorator order in `docs/api/utils.md` (`set_index_if_possible` must stay outermost), removed the redundant `initialize()`/`login()` calls inside `with` blocks across the docs (the context managers already handle both; the removed `client.login(config.login, ...)` examples also failed pyright strict), corrected the logging-level (INFO, not DEBUG) and conversion-default prose, and aligned Best Practices with the new raising behavior.

## Intentional behavior changes

- `with Mt5Client(...)` and auto-initialization now **raise** `Mt5RuntimeError` on a dead terminal/connection instead of continuing silently; `*_total` methods raise instead of returning `None`.
- Conflicting filter combinations raise `ValueError` (the logging decorator lets `ValueError` propagate unwrapped); the history `symbol` filter is now an exact match.

## Release

- Version bumped to 1.1.1

## QA

- `.agents/skills/local-qa/scripts/qa.sh` — all checks passed
- `uv run pytest` — 421 passed, 33 skipped (Windows-only), 100% branch coverage
- `uv run ruff check .` / `uv run pyright` — clean
- `uv run mkdocs build` — succeeds

Windows/MT5 note: all changes are exercised via the existing mock-based test suite; no live-terminal behavior was verified (CI runs on Windows).

Closes #99
Closes #100
Closes #101
Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)