### PR TITLE
Add enforceable public API and architecture contract (#105)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,16 @@ Apply KISS, DRY, and YAGNI. Keep changes straightforward, remove duplication
 only when it improves clarity, and do not add extension points or features before
 they are needed. Prefer small, test-backed changes that are easy to review.
 
+## Architecture Boundary
+
+pdmt5 is a low-level adapter over `MetaTrader5`. It owns direct MT5 wrappers,
+lifecycle primitives, canonical constants/parsers, and native-result
+dictionary/DataFrame conversion. Keep market-order construction, filling-mode
+selection, sizing, position workflows, retries, persistence, reporting, CLI or
+batch workflows, and strategy/risk/backtesting features in `mt5cli` or the
+consuming application. Proposals in those areas should be directed downstream
+unless they are unavoidable low-level MT5 primitives.
+
 ## Testing Guidelines
 
 Tests use `pytest`, `pytest-mock`, doctests, and `pytest-cov`. Name files

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Low-level MetaTrader 5 wrapper and pandas/dict conversion package
 
 High-level trading orchestration (market-order construction, margin-budget sizing, position lifecycle management, strategy or batch workflows) is out of scope. Those concerns belong in downstream applications or tools such as mt5cli.
 
+See the [architecture contract](docs/architecture.md) for the stable root API,
+return shapes, lifecycle and error semantics, dependency direction, and the
+full list of responsibilities deliberately left to `mt5cli` or downstream
+applications.
+
 ### Key Features
 
 - **Pandas Integration**: DataFrame and dictionary helpers for easy analysis
@@ -170,16 +175,14 @@ and other application layers. The constants module does not import
 generation without a live terminal.
 
 ```python
-from pdmt5 import (
+from pdmt5 import parse_copy_ticks, parse_order_type, parse_timeframe
+from pdmt5.constants import (
     list_copy_ticks_names,
     list_copy_ticks_values,
     list_order_type_names,
     list_order_type_values,
     list_timeframe_names,
     list_timeframe_values,
-    parse_copy_ticks,
-    parse_order_type,
-    parse_timeframe,
 )
 
 parse_timeframe("TIMEFRAME_M1")  # 1

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,6 +2,10 @@
 
 This section contains the complete API documentation for pdmt5.
 
+The [architecture contract](../architecture.md) defines the stable package-root
+API and the boundary between pdmt5's low-level MT5 primitives and downstream
+application workflows.
+
 ## Modules
 
 The pdmt5 package consists of the following modules:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,73 @@
+# Architecture contract
+
+pdmt5 is a small adapter over the official `MetaTrader5` Python package. Direct
+pdmt5 use is appropriate for low-level MT5 access. Application execution
+workflows belong in `mt5cli` or the consuming application.
+
+```text
+mteor or another application
+    -> mt5cli
+        -> pdmt5
+            -> MetaTrader5
+```
+
+## Stable package-root API
+
+Only these names are stable package-root exports:
+
+- `__version__`
+- `Mt5Client`, `Mt5DataClient`, `Mt5Config`, `Mt5RuntimeError`
+- `TIMEFRAME_MAP`, `COPY_TICKS_MAP`, `ORDER_TYPE_MAP`
+- `parse_timeframe`, `parse_copy_ticks`, `parse_order_type`
+
+Use `pdmt5.constants` for constant-name/value introspection helpers. Those
+helpers are intentionally no longer re-exported from `pdmt5`; this keeps the
+root API focused on client construction and canonical parsing.
+
+The deliberately public module APIs are `pdmt5.mt5` (`Mt5Client`,
+`Mt5RuntimeError`), `pdmt5.dataframe` (`Mt5Config`, `Mt5DataClient`), and the
+explicit `pdmt5.constants.__all__`. `pdmt5.utils` is implementation-only.
+
+## Owned low-level responsibilities
+
+pdmt5 owns direct wrappers around official `MetaTrader5` functions, including
+terminal initialization, login, shutdown, account and terminal access, market
+data, market book, orders, positions, margin, profit, history, `order_check`,
+and `order_send`. It owns `Mt5Config`, `Mt5RuntimeError`, canonical MT5
+constants/parsers, and native-result conversion to dictionaries and pandas
+DataFrames.
+
+`Mt5Client` owns raw MT5 access and lifecycle primitives. Its context manager
+initializes on entry and always shuts down on exit; failed initialization raises
+`Mt5RuntimeError`. `Mt5DataClient` owns config-aware lifecycle: its context
+manager initializes and logs in using `Mt5Config`, then shuts down on exit.
+
+## Return shapes and errors
+
+Raw `Mt5Client` methods return the native MT5 result (or the corresponding
+scalar). `Mt5DataClient` methods ending in `_as_dict` return a single
+dictionary, those ending in `_as_dicts` return a list of dictionaries, and
+those ending in `_as_df` return a pandas `DataFrame`. DataFrame and dictionary
+helpers convert MT5 time fields to timezone-naive trade-server timestamps by
+default; pass `skip_to_datetime=True` where supported to retain raw epochs.
+
+Invalid pdmt5 inputs, such as conflicting filters, invalid date ranges, or
+non-positive counts, raise `ValueError`. An MT5 failure, including a `None`
+response, failed initialization, or an underlying MT5 exception, raises
+`Mt5RuntimeError` with MT5 error context.
+
+## Explicit non-goals
+
+pdmt5 does not construct market-order requests, select filling modes, size
+positions from margin budgets, orchestrate position lifecycles, or implement
+close, reversal, or retry workflows. It does not provide SQLite or other
+persistence; CSV, JSON, Parquet, Grafana, or reporting workflows; command-line
+or batch workflows; strategies, signals, risk thresholds, betting,
+backtesting, or optimization. Put these policies and workflows in `mt5cli` or
+the downstream application.
+
+## Enforcement
+
+Contract tests assert the root allowlist and module `__all__` declarations and
+scan every production module for imports of `mt5cli` or `mteor`. Any new root
+export, accidental module API, or reverse dependency fails CI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,9 +52,27 @@ helpers convert MT5 time fields to timezone-naive trade-server timestamps by
 default; pass `skip_to_datetime=True` where supported to retain raw epochs.
 
 Invalid pdmt5 inputs, such as conflicting filters, invalid date ranges, or
-non-positive counts, raise `ValueError`. An MT5 failure, including a `None`
-response, failed initialization, or an underlying MT5 exception, raises
-`Mt5RuntimeError` with MT5 error context.
+non-positive counts, raise `ValueError`.
+
+Boolean-returning MT5 wrappers, such as `initialize()`, `login()`,
+`symbol_select()`, `market_book_add()`, and `market_book_release()`, report an
+MT5-side failure by returning `False`. pdmt5 does not convert that `False`
+into an exception, so callers must check the return value themselves.
+
+Methods whose native MT5 result is validated for `None` (via
+`_validate_mt5_response_is_not_none()`) raise `Mt5RuntimeError` only when MT5
+returns `None`; any other response, including one whose fields indicate
+failure (such as an `order_send()` `retcode`), is returned as-is.
+
+Failed initialization raises `Mt5RuntimeError` through `_initialize_or_raise()`,
+which runs both when entering the `Mt5Client` context manager and implicitly,
+via `_initialize_if_needed()`, before other raw MT5 calls that require an
+active connection. `Mt5DataClient.initialize_and_login_mt5()`, used by its own
+context manager, raises `Mt5RuntimeError` after retrying initialization and
+login failures.
+
+Any unexpected exception raised by the underlying `MetaTrader5` package is
+wrapped and re-raised as `Mt5RuntimeError` with MT5 error context.
 
 ## Explicit non-goals
 
@@ -69,5 +87,6 @@ the downstream application.
 ## Enforcement
 
 Contract tests assert the root allowlist and module `__all__` declarations and
-scan every production module for imports of `mt5cli` or `mteor`. Any new root
-export, accidental module API, or reverse dependency fails CI.
+recursively scan every production module under `pdmt5/`, including nested
+subpackages, for imports of `mt5cli` or `mteor`. Any new root export,
+accidental module API, or reverse dependency fails CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@ Low-level MetaTrader 5 wrapper and pandas/dict conversion package.
 
 pdmt5 is a Python library that provides a low-level wrapper around the MetaTrader 5 (MT5) API with pandas DataFrame and dictionary conversion helpers. It simplifies data access and conversion for financial market data analysis.
 
+For the stable root API and the low-level/downstream responsibility split, see
+the [architecture contract](architecture.md).
+
 ## Features
 
 - **MetaTrader 5 Integration**: Direct connection to MetaTrader 5 platform (Windows only)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Architecture contract: architecture.md
   - API Reference:
     - Overview: api/index.md
     - MetaTrader5: api/mt5.md

--- a/pdmt5/__init__.py
+++ b/pdmt5/__init__.py
@@ -1,23 +1,11 @@
-"""pdmt5: Pandas-based data handler for MetaTrader 5."""
+"""Stable package-root API for low-level MetaTrader 5 access."""
 
-from importlib.metadata import version
+from importlib.metadata import version as _version
 
 from .constants import (
     COPY_TICKS_MAP,
     ORDER_TYPE_MAP,
     TIMEFRAME_MAP,
-    get_copy_ticks_name,
-    get_copy_ticks_value,
-    get_order_type_name,
-    get_order_type_value,
-    get_timeframe_name,
-    get_timeframe_value,
-    list_copy_ticks_names,
-    list_copy_ticks_values,
-    list_order_type_names,
-    list_order_type_values,
-    list_timeframe_names,
-    list_timeframe_values,
     parse_copy_ticks,
     parse_order_type,
     parse_timeframe,
@@ -25,7 +13,7 @@ from .constants import (
 from .dataframe import Mt5Config, Mt5DataClient
 from .mt5 import Mt5Client, Mt5RuntimeError
 
-__version__ = version(__package__) if __package__ else None
+__version__ = _version(__package__) if __package__ else None
 
 __all__ = [
     "COPY_TICKS_MAP",
@@ -35,18 +23,7 @@ __all__ = [
     "Mt5Config",
     "Mt5DataClient",
     "Mt5RuntimeError",
-    "get_copy_ticks_name",
-    "get_copy_ticks_value",
-    "get_order_type_name",
-    "get_order_type_value",
-    "get_timeframe_name",
-    "get_timeframe_value",
-    "list_copy_ticks_names",
-    "list_copy_ticks_values",
-    "list_order_type_names",
-    "list_order_type_values",
-    "list_timeframe_names",
-    "list_timeframe_values",
+    "__version__",
     "parse_copy_ticks",
     "parse_order_type",
     "parse_timeframe",

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -18,6 +18,8 @@ from .utils import (
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["Mt5Config", "Mt5DataClient"]
+
 
 class Mt5Config(BaseModel):
     """Configuration for MetaTrader5 connection."""

--- a/pdmt5/mt5.py
+++ b/pdmt5/mt5.py
@@ -22,6 +22,8 @@ R = TypeVar("R")
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["Mt5Client", "Mt5RuntimeError"]
+
 
 class Mt5RuntimeError(RuntimeError):
     """MetaTrader5 specific runtime error.

--- a/pdmt5/utils.py
+++ b/pdmt5/utils.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 R = TypeVar("R")
 
+__all__: list[str] = []
+
 
 def detect_and_convert_time_to_datetime(
     skip_toggle: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.1.1"
+version = "1.1.2"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.1.2"
+version = "1.2.0"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -52,6 +52,24 @@ def test_module_public_apis_match_contract() -> None:
 
 def test_production_modules_do_not_import_downstream_packages() -> None:
     """Test the dependency direction never points from pdmt5 downstream."""
-    for module_path in _PACKAGE_ROOT.glob("*.py"):
+    for module_path in _PACKAGE_ROOT.rglob("*.py"):
         imported_names = _imported_root_names(module_path)
-        assert not imported_names & _FORBIDDEN_DOWNSTREAM_PACKAGES, module_path
+        forbidden_imports = imported_names & _FORBIDDEN_DOWNSTREAM_PACKAGES
+        assert not forbidden_imports, (
+            f"{module_path} imports forbidden downstream package(s):"
+            f" {sorted(forbidden_imports)}"
+        )
+
+
+def test_nested_module_importing_downstream_package_is_detected(
+    tmp_path: Path,
+) -> None:
+    """Test that the recursive scan reaches modules under nested subpackages."""
+    nested_module = tmp_path / "execution" / "workflow.py"
+    nested_module.parent.mkdir(parents=True)
+    nested_module.write_text("import mt5cli\n", encoding="utf-8")
+
+    imported_names = _imported_root_names(nested_module)
+
+    assert imported_names & _FORBIDDEN_DOWNSTREAM_PACKAGES == {"mt5cli"}
+    assert list(tmp_path.rglob("*.py")) == [nested_module]

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,57 @@
+"""Contract tests that keep pdmt5 at the low-level MT5 boundary."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from pdmt5 import constants, dataframe, mt5, utils
+
+_PACKAGE_ROOT = Path(__file__).parents[1] / "pdmt5"
+_FORBIDDEN_DOWNSTREAM_PACKAGES = {"mt5cli", "mteor"}
+
+
+def _imported_root_names(module_path: Path) -> set[str]:
+    """Return absolute top-level packages imported by one production module."""
+    module = ast.parse(module_path.read_text(encoding="utf-8"))
+    imported_names: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            imported_names.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported_names.add(node.module.split(".")[0])
+    return imported_names
+
+
+def test_module_public_apis_match_contract() -> None:
+    """Test that every production module has a deliberate public API."""
+    assert mt5.__all__ == ["Mt5Client", "Mt5RuntimeError"]
+    assert dataframe.__all__ == ["Mt5Config", "Mt5DataClient"]
+    assert constants.__all__ == [
+        "COPY_TICKS_MAP",
+        "ORDER_TYPE_MAP",
+        "TIMEFRAME_MAP",
+        "get_copy_ticks_name",
+        "get_copy_ticks_value",
+        "get_order_type_name",
+        "get_order_type_value",
+        "get_timeframe_name",
+        "get_timeframe_value",
+        "list_copy_ticks_names",
+        "list_copy_ticks_values",
+        "list_order_type_names",
+        "list_order_type_values",
+        "list_timeframe_names",
+        "list_timeframe_values",
+        "parse_copy_ticks",
+        "parse_order_type",
+        "parse_timeframe",
+    ]
+    assert utils.__all__ == []
+
+
+def test_production_modules_do_not_import_downstream_packages() -> None:
+    """Test the dependency direction never points from pdmt5 downstream."""
+    for module_path in _PACKAGE_ROOT.glob("*.py"):
+        imported_names = _imported_root_names(module_path)
+        assert not imported_names & _FORBIDDEN_DOWNSTREAM_PACKAGES, module_path

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import pytest
 
-import pdmt5
+from pdmt5 import constants
 from pdmt5.constants import (
     COPY_TICKS_MAP,
     ORDER_TYPE_MAP,
@@ -288,9 +288,9 @@ def test_public_constant_maps_are_immutable_and_do_not_affect_parsers(
     ],
 )
 def test_constants_exports_available(export: str) -> None:
-    """Test new public constants APIs are exported by pdmt5."""
-    assert hasattr(pdmt5, export), f"Missing export: {export}"
-    assert export in pdmt5.__all__, f"Export {export} not in __all__"
+    """Test public constants APIs are exported by pdmt5.constants."""
+    assert hasattr(constants, export), f"Missing export: {export}"
+    assert export in constants.__all__, f"Export {export} not in __all__"
 
 
 @_WINDOWS_ONLY

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,20 @@ import pytest
 
 import pdmt5
 
+_STABLE_ROOT_EXPORTS = {
+    "__version__",
+    "COPY_TICKS_MAP",
+    "ORDER_TYPE_MAP",
+    "TIMEFRAME_MAP",
+    "Mt5Client",
+    "Mt5Config",
+    "Mt5DataClient",
+    "Mt5RuntimeError",
+    "parse_copy_ticks",
+    "parse_order_type",
+    "parse_timeframe",
+}
+
 
 class TestInit:
     """Test package initialization."""
@@ -13,16 +27,30 @@ class TestInit:
         assert hasattr(pdmt5, "__version__")
         assert pdmt5.__version__ is not None
 
+    def test_stable_root_exports_match_contract(self) -> None:
+        """Test that the root API is an explicit, importable allowlist."""
+        assert set(pdmt5.__all__) == _STABLE_ROOT_EXPORTS
+        assert all(hasattr(pdmt5, export) for export in pdmt5.__all__)
+
     @pytest.mark.parametrize(
-        "export",
+        "removed_export",
         [
-            "Mt5Client",
-            "Mt5Config",
-            "Mt5DataClient",
-            "Mt5RuntimeError",
+            "get_copy_ticks_name",
+            "get_copy_ticks_value",
+            "get_order_type_name",
+            "get_order_type_value",
+            "get_timeframe_name",
+            "get_timeframe_value",
+            "list_copy_ticks_names",
+            "list_copy_ticks_values",
+            "list_order_type_names",
+            "list_order_type_values",
+            "list_timeframe_names",
+            "list_timeframe_values",
         ],
     )
-    def test_exports_available(self, export: str) -> None:
-        """Test that expected exports are accessible and listed in __all__."""
-        assert hasattr(pdmt5, export), f"Missing export: {export}"
-        assert export in pdmt5.__all__, f"Export {export} not in __all__"
+    def test_compatibility_helpers_are_not_root_exports(
+        self, removed_export: str
+    ) -> None:
+        """Test that constant introspection stays in pdmt5.constants."""
+        assert not hasattr(pdmt5, removed_export)

--- a/tests/test_mt5.py
+++ b/tests/test_mt5.py
@@ -361,6 +361,14 @@ class TestMt5Client:
         assert result is True
         mock_mt5.symbol_select.assert_called_once_with("EURUSD", True)  # noqa: FBT003
 
+    def test_symbol_select_pass_through_false(
+        self, initialized_client: Mt5Client, mock_mt5: Mock
+    ) -> None:
+        """Test symbol_select returns False without raising on MT5-side failure."""
+        mock_mt5.symbol_select.return_value = False
+
+        assert initialized_client.symbol_select("EURUSD") is False
+
     @pytest.mark.parametrize("method_name", ["market_book_add", "market_book_release"])
     def test_market_book_actions(
         self, initialized_client: Mt5Client, mock_mt5: Mock, method_name: str

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

- Add `docs/architecture.md` documenting the stable root API, lifecycle ownership, return shapes, error semantics, owned primitives, and explicit downstream non-goals.
- Narrow `pdmt5` root exports to the stable allowlist (`__version__`, client/config/error types, canonical maps, parsers); constant introspection helpers remain public from `pdmt5.constants`.
- Add explicit module `__all__` contracts and AST-based contract tests that enforce the root allowlist and block reverse imports of `mt5cli` or `mteor`.
- Update contributor guidance (`AGENTS.md`, `README.md`, docs nav) to point high-level workflows downstream.
- Correct the documented error contract so it distinguishes boolean-returning MT5 wrappers (`initialize()`, `login()`, `symbol_select()`, `market_book_add()`, `market_book_release()`), which may return `False` on an MT5-side failure without raising, from `None`-response validation, failed/implicit initialization, and unexpected-exception wrapping, all of which raise `Mt5RuntimeError`. Add a test proving `symbol_select()` passes through `False` without raising.
- Make the reverse-dependency architecture check recursive (`Path.rglob`) so it scans every production module under `pdmt5/`, including nested subpackages, with a clearer failure message naming the offending file and forbidden package(s); add a test proving a forbidden import in a nested module is detected.
- Bump package version to `1.2.0`.

Fixes #105

## Test plan

- [x] `.agents/skills/local-qa/scripts/qa.sh` (Ruff, Pyright, pytest: 434 passed / 33 Windows-only skipped, 100% coverage)
- [x] `uv run mkdocs build --strict`
- [ ] Verify Windows CI passes on the PR branch