### PR TITLE
Configure uv package cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ Repository = "https://github.com/dceoy/pdmt5.git"
 
 [tool.uv]
 required-environments = ["platform_system == 'Windows'"]
+exclude-newer = "1 week"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,10 @@ required-markers = [
     "sys_platform == 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-07-13T15:36:20.673868809Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -323,7 +327,7 @@ name = "metatrader5"
 version = "5.0.5735"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/0b/3dd5143f14319dca393a3bcf11ddf24f36f16dfb8c6d1bf2b193ce0c5733/metatrader5-5.0.5735-cp311-cp311-win_amd64.whl", hash = "sha256:0d05b69cef5eb3f43ea47cb6d36dac0e7e15f82a4fb77974439c565daa54d1c9", size = 48091, upload-time = "2026-04-04T16:44:08.677Z" },


### PR DESCRIPTION
## Summary
- configure a one-week dependency cooldown in `pyproject.toml`
- preserve the Windows required-environment constraint
- regenerate `uv.lock` with uv 0.10.0
- keep all dependencies, including development tools, subject to the cooldown

## Configuration
```toml
[tool.uv]
required-environments = ["platform_system == 'Windows'"]
exclude-newer = "1 week"
```

## Validation
- follows uv's documented dependency-cooldown configuration
- `uv.lock` records the resolved cutoff and `P1W` span
- the PR contains a single commit and changes only `pyproject.toml` and `uv.lock`