### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner
+* @dceoy


### PR DESCRIPTION
## Summary
- add `.github/CODEOWNERS`
- assign `@dceoy` as the default owner for all files

## Validation
- configuration-only change; no runtime behavior is affected