### PR TITLE
Avoid redundant MT5 login after initialization

### DIFF
--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -155,10 +155,16 @@ class Mt5DataClient(Mt5Client):
             if login_value is None:
                 return
             try:
-                active_login = getattr(self.account_info(), "login", None)
+                active_account = self.account_info()
             except Mt5RuntimeError:
-                active_login = None
-            if active_login == login_value:
+                active_account = None
+            if active_account is not None and (
+                getattr(active_account, "login", None) == login_value
+                and (
+                    server_value is None
+                    or getattr(active_account, "server", None) == server_value
+                )
+            ):
                 return
             try:
                 if self.login(
@@ -694,8 +700,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date in trade-server time (not UTC).
-            date_to: End date in trade-server time (not UTC).
+            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
 
@@ -728,8 +734,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date in trade-server time (not UTC).
-            date_to: End date in trade-server time (not UTC).
+            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
@@ -1036,10 +1042,8 @@ class Mt5DataClient(Mt5Client):
         """Get historical deals with optional filters as a list of dictionaries.
 
         Args:
-            date_from: Start date in trade-server time, not UTC (required if
-                not using ticket/position).
-            date_to: End date in trade-server time, not UTC (required if not
-                using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -109,7 +109,13 @@ class Mt5DataClient(Mt5Client):
         server: str | None = None,
         timeout: int | None = None,
     ) -> None:
-        """Initialize an MT5 connection with config-aware retry and login support.
+        """Initialize MT5 and ensure the requested account is active.
+
+        ``MetaTrader5.initialize()`` accepts account credentials and normally
+        connects directly to the requested account. After initialization, this
+        method verifies the active account and only calls ``login()`` when the
+        terminal reports a different account, avoiding redundant authentication
+        while preserving account-switch fallback behavior.
 
         Args:
             path: Path to terminal EXE file (overrides config).
@@ -119,7 +125,7 @@ class Mt5DataClient(Mt5Client):
             timeout: Connection timeout (overrides config).
 
         Raises:
-            Mt5RuntimeError: If initialization fails after retries.
+            Mt5RuntimeError: If initialization or account selection fails after retries.
         """
         path = path or self.config.path
         login_value = login if login is not None else self.config.login
@@ -146,8 +152,16 @@ class Mt5DataClient(Mt5Client):
             ):
                 last_error_value = self.last_error()
                 continue
+            if login_value is None:
+                return
             try:
-                if login_value is None or self.login(
+                active_login = getattr(self.account_info(), "login", None)
+            except Mt5RuntimeError:
+                active_login = None
+            if active_login == login_value:
+                return
+            try:
+                if self.login(
                     login=login_value,
                     password=password_value,
                     server=server_value,

--- a/pdmt5/dataframe.py
+++ b/pdmt5/dataframe.py
@@ -700,8 +700,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
-            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
 
@@ -734,8 +734,8 @@ class Mt5DataClient(Mt5Client):
 
         Args:
             symbol: Symbol name.
-            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
-            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
+            date_from: Start date in trade-server time (not UTC).
+            date_to: End date in trade-server time (not UTC).
             flags: Tick flags (use constants from MetaTrader5).
             skip_to_datetime: Whether to skip converting time to datetime.
             index_keys: Column name to set as index if provided.
@@ -1042,8 +1042,10 @@ class Mt5DataClient(Mt5Client):
         """Get historical deals with optional filters as a list of dictionaries.
 
         Args:
-            date_from: Start date in trade-server time, not UTC (required if not using ticket/position).
-            date_to: End date in trade-server time, not UTC (required if not using ticket/position).
+            date_from: Start date in trade-server time, not UTC (required if
+                not using ticket/position).
+            date_to: End date in trade-server time, not UTC (required if not
+                using ticket/position).
             group: Optional group filter. Mutually exclusive with symbol.
             symbol: Optional symbol filter matching the symbol name exactly.
                 Mutually exclusive with group.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdmt5"
-version = "1.2.1"
+version = "1.2.2"
 description = "Low-level MetaTrader 5 wrapper and pandas/dict conversion package"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,6 +1,7 @@
 """Focused tests for config-aware MetaTrader5 initialization."""
 
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+from typing import Any, cast
 
 from pytest_mock import MockerFixture
 
@@ -10,16 +11,21 @@ from tests.helpers import create_mock_mt5_module
 _MT5_METHODS = ("initialize", "login", "account_info", "last_error", "shutdown")
 
 
-def _make_client(mocker: MockerFixture, *, active_login: int) -> tuple[object, Mt5DataClient]:
+def _make_client(
+    mocker: MockerFixture,
+    *,
+    active_login: int,
+) -> tuple[ModuleType, Mt5DataClient]:
     mt5 = create_mock_mt5_module(
         mocker,
         methods=_MT5_METHODS,
         constants={"RES_S_OK": 1},
     )
-    mt5.initialize.return_value = True  # type: ignore[attr-defined]
-    mt5.login.return_value = True  # type: ignore[attr-defined]
-    mt5.account_info.return_value = SimpleNamespace(login=active_login)  # type: ignore[attr-defined]
-    mt5.last_error.return_value = (1, "Success")  # type: ignore[attr-defined]
+    mt5_any = cast("Any", mt5)
+    mt5_any.initialize.return_value = True
+    mt5_any.login.return_value = True
+    mt5_any.account_info.return_value = SimpleNamespace(login=active_login)
+    mt5_any.last_error.return_value = (1, "Success")
     client = Mt5DataClient(
         mt5=mt5,
         config=Mt5Config(
@@ -38,23 +44,43 @@ def test_initialize_skips_redundant_login_for_active_account(
 ) -> None:
     """Do not authenticate twice when initialize already selected the account."""
     mt5, client = _make_client(mocker, active_login=123456)
+    mt5_any = cast("Any", mt5)
 
     client.initialize_and_login_mt5()
 
-    mt5.account_info.assert_called_once()  # type: ignore[attr-defined]
-    mt5.login.assert_not_called()  # type: ignore[attr-defined]
+    mt5_any.account_info.assert_called_once()
+    mt5_any.login.assert_not_called()
 
 
 def test_initialize_falls_back_to_login_for_different_active_account(
     mocker: MockerFixture,
 ) -> None:
-    """Preserve explicit login fallback when initialize leaves another account active."""
+    """Use explicit login when initialize leaves another account active."""
     mt5, client = _make_client(mocker, active_login=654321)
+    mt5_any = cast("Any", mt5)
 
     client.initialize_and_login_mt5()
 
-    mt5.account_info.assert_called_once()  # type: ignore[attr-defined]
-    mt5.login.assert_called_once_with(  # type: ignore[attr-defined]
+    mt5_any.account_info.assert_called_once()
+    mt5_any.login.assert_called_once_with(
+        123456,
+        password="secret",
+        server="Demo",
+        timeout=60000,
+    )
+
+
+def test_initialize_falls_back_to_login_when_account_info_is_unavailable(
+    mocker: MockerFixture,
+) -> None:
+    """Use explicit login if active-account verification cannot return data."""
+    mt5, client = _make_client(mocker, active_login=123456)
+    mt5_any = cast("Any", mt5)
+    mt5_any.account_info.return_value = None
+
+    client.initialize_and_login_mt5()
+
+    mt5_any.login.assert_called_once_with(
         123456,
         password="secret",
         server="Demo",

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -12,7 +12,11 @@ from tests.helpers import create_mock_mt5_module
 _MT5_METHODS = ("initialize", "login", "account_info", "last_error", "shutdown")
 
 
-def _make_client(mocker: MockerFixture) -> tuple[ModuleType, Mt5DataClient]:
+def _make_client(
+    mocker: MockerFixture,
+    *,
+    server: str | None,
+) -> tuple[ModuleType, Mt5DataClient]:
     mt5 = create_mock_mt5_module(
         mocker,
         methods=_MT5_METHODS,
@@ -27,7 +31,7 @@ def _make_client(mocker: MockerFixture) -> tuple[ModuleType, Mt5DataClient]:
         config=Mt5Config(
             login=123456,
             password="secret",
-            server="Demo",
+            server=server,
             timeout=60000,
         ),
         retry_count=0,
@@ -36,34 +40,44 @@ def _make_client(mocker: MockerFixture) -> tuple[ModuleType, Mt5DataClient]:
 
 
 @pytest.mark.parametrize(
-    ("active_account", "should_login"),
+    ("active_account", "requested_server", "should_login"),
     [
         pytest.param(
             SimpleNamespace(login=123456, server="Demo"),
+            "Demo",
             False,
             id="matching-account",
         ),
         pytest.param(
+            SimpleNamespace(login=123456, server="Other"),
+            None,
+            False,
+            id="matching-login-without-requested-server",
+        ),
+        pytest.param(
             SimpleNamespace(login=654321, server="Demo"),
+            "Demo",
             True,
             id="different-login",
         ),
         pytest.param(
             SimpleNamespace(login=123456, server="Other"),
+            "Demo",
             True,
             id="different-server",
         ),
-        pytest.param(None, True, id="account-info-unavailable"),
+        pytest.param(None, "Demo", True, id="account-info-unavailable"),
     ],
 )
 def test_initialize_uses_explicit_login_only_when_requested_account_is_not_active(
     mocker: MockerFixture,
     active_account: SimpleNamespace | None,
+    requested_server: str | None,
     *,
     should_login: bool,
 ) -> None:
-    """Skip only when both the requested login and server are already active."""
-    mt5, client = _make_client(mocker)
+    """Skip only when the requested account identity is already active."""
+    mt5, client = _make_client(mocker, server=requested_server)
     mt5_any = cast("Any", mt5)
     mt5_any.account_info.return_value = active_account
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3,6 +3,7 @@
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
+import pytest
 from pytest_mock import MockerFixture
 
 from pdmt5.dataframe import Mt5Config, Mt5DataClient
@@ -11,11 +12,7 @@ from tests.helpers import create_mock_mt5_module
 _MT5_METHODS = ("initialize", "login", "account_info", "last_error", "shutdown")
 
 
-def _make_client(
-    mocker: MockerFixture,
-    *,
-    active_login: int,
-) -> tuple[ModuleType, Mt5DataClient]:
+def _make_client(mocker: MockerFixture) -> tuple[ModuleType, Mt5DataClient]:
     mt5 = create_mock_mt5_module(
         mocker,
         methods=_MT5_METHODS,
@@ -24,7 +21,6 @@ def _make_client(
     mt5_any = cast("Any", mt5)
     mt5_any.initialize.return_value = True
     mt5_any.login.return_value = True
-    mt5_any.account_info.return_value = SimpleNamespace(login=active_login)
     mt5_any.last_error.return_value = (1, "Success")
     client = Mt5DataClient(
         mt5=mt5,
@@ -39,50 +35,47 @@ def _make_client(
     return mt5, client
 
 
-def test_initialize_skips_redundant_login_for_active_account(
+@pytest.mark.parametrize(
+    ("active_account", "should_login"),
+    [
+        pytest.param(
+            SimpleNamespace(login=123456, server="Demo"),
+            False,
+            id="matching-account",
+        ),
+        pytest.param(
+            SimpleNamespace(login=654321, server="Demo"),
+            True,
+            id="different-login",
+        ),
+        pytest.param(
+            SimpleNamespace(login=123456, server="Other"),
+            True,
+            id="different-server",
+        ),
+        pytest.param(None, True, id="account-info-unavailable"),
+    ],
+)
+def test_initialize_uses_explicit_login_only_when_requested_account_is_not_active(
     mocker: MockerFixture,
+    active_account: SimpleNamespace | None,
+    *,
+    should_login: bool,
 ) -> None:
-    """Do not authenticate twice when initialize already selected the account."""
-    mt5, client = _make_client(mocker, active_login=123456)
+    """Skip only when both the requested login and server are already active."""
+    mt5, client = _make_client(mocker)
     mt5_any = cast("Any", mt5)
+    mt5_any.account_info.return_value = active_account
 
     client.initialize_and_login_mt5()
 
     mt5_any.account_info.assert_called_once()
-    mt5_any.login.assert_not_called()
-
-
-def test_initialize_falls_back_to_login_for_different_active_account(
-    mocker: MockerFixture,
-) -> None:
-    """Use explicit login when initialize leaves another account active."""
-    mt5, client = _make_client(mocker, active_login=654321)
-    mt5_any = cast("Any", mt5)
-
-    client.initialize_and_login_mt5()
-
-    mt5_any.account_info.assert_called_once()
-    mt5_any.login.assert_called_once_with(
-        123456,
-        password="secret",
-        server="Demo",
-        timeout=60000,
-    )
-
-
-def test_initialize_falls_back_to_login_when_account_info_is_unavailable(
-    mocker: MockerFixture,
-) -> None:
-    """Use explicit login if active-account verification cannot return data."""
-    mt5, client = _make_client(mocker, active_login=123456)
-    mt5_any = cast("Any", mt5)
-    mt5_any.account_info.return_value = None
-
-    client.initialize_and_login_mt5()
-
-    mt5_any.login.assert_called_once_with(
-        123456,
-        password="secret",
-        server="Demo",
-        timeout=60000,
-    )
+    if should_login:
+        mt5_any.login.assert_called_once_with(
+            123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        )
+    else:
+        mt5_any.login.assert_not_called()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,0 +1,62 @@
+"""Focused tests for config-aware MetaTrader5 initialization."""
+
+from types import SimpleNamespace
+
+from pytest_mock import MockerFixture
+
+from pdmt5.dataframe import Mt5Config, Mt5DataClient
+from tests.helpers import create_mock_mt5_module
+
+_MT5_METHODS = ("initialize", "login", "account_info", "last_error", "shutdown")
+
+
+def _make_client(mocker: MockerFixture, *, active_login: int) -> tuple[object, Mt5DataClient]:
+    mt5 = create_mock_mt5_module(
+        mocker,
+        methods=_MT5_METHODS,
+        constants={"RES_S_OK": 1},
+    )
+    mt5.initialize.return_value = True  # type: ignore[attr-defined]
+    mt5.login.return_value = True  # type: ignore[attr-defined]
+    mt5.account_info.return_value = SimpleNamespace(login=active_login)  # type: ignore[attr-defined]
+    mt5.last_error.return_value = (1, "Success")  # type: ignore[attr-defined]
+    client = Mt5DataClient(
+        mt5=mt5,
+        config=Mt5Config(
+            login=123456,
+            password="secret",
+            server="Demo",
+            timeout=60000,
+        ),
+        retry_count=0,
+    )
+    return mt5, client
+
+
+def test_initialize_skips_redundant_login_for_active_account(
+    mocker: MockerFixture,
+) -> None:
+    """Do not authenticate twice when initialize already selected the account."""
+    mt5, client = _make_client(mocker, active_login=123456)
+
+    client.initialize_and_login_mt5()
+
+    mt5.account_info.assert_called_once()  # type: ignore[attr-defined]
+    mt5.login.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_initialize_falls_back_to_login_for_different_active_account(
+    mocker: MockerFixture,
+) -> None:
+    """Preserve explicit login fallback when initialize leaves another account active."""
+    mt5, client = _make_client(mocker, active_login=654321)
+
+    client.initialize_and_login_mt5()
+
+    mt5.account_info.assert_called_once()  # type: ignore[attr-defined]
+    mt5.login.assert_called_once_with(  # type: ignore[attr-defined]
+        123456,
+        password="secret",
+        server="Demo",
+        timeout=60000,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

- Avoid a second `MetaTrader5.login()` call when `MetaTrader5.initialize()` has already connected to the requested account.
- Verify the active account after initialization and return immediately only when its login matches the requested login and, when specified, its server matches the requested server.
- Preserve the existing explicit `login()` fallback when the terminal reports a different login/server or active-account inspection is unavailable.
- Keep the public `initialize_and_login_mt5()` and `login()` APIs unchanged for downstream callers such as `mt5cli` and `mt5api`.
- Cover the matching-account, optional-server, different-login, different-server, and account-info-unavailable paths with a parametrized test matrix.

## Why

`MetaTrader5.initialize()` already accepts `login`, `password`, and `server` and can establish the requested account connection. The previous implementation unconditionally followed a successful credentialed `initialize()` with the same credentials through `login()`, causing redundant authentication during normal startup.

The explicit `login()` operation is still useful for account switching. This change skips it only when the active account matches the requested identity, including the requested server when one is configured.

## Impact

Normal startup performs one authentication path instead of two when the requested account is already active. If initialization leaves a different login or broker server active, the previous explicit `login()` fallback remains in place. Public method names and downstream call sites do not change.

## Validation

- Parametrized unit coverage for matching login/server and matching login with no requested server.
- Parametrized unit coverage for different login and same-login/different-server fallback paths.
- Parametrized unit coverage for unavailable active-account information.
- Existing initialization/login retry and failure-path tests remain unchanged and continue to exercise the fallback path.
- GitHub Actions `python-test / test` passed.
- GitHub Actions `python-lint-and-scan / lint-and-scan` passed, including Ruff and Pyright.
