### PR TITLE
Use uvx for local QA Python tools

### DIFF
--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -18,7 +18,7 @@ uv run pytest
 npx -y prettier --write './**/*.md'
 
 # GitHub Actions
-zizmor --fix=safe .github/workflows
+uvx zizmor --fix=safe .github/workflows
 git ls-files -z -- '.github/workflows/*.yml' | xargs -0 -t actionlint
-git ls-files -z -- '.github/workflows/*.yml' | xargs -0 -t yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'
-checkov --framework=all --output=github_failed_only --directory=.
+git ls-files -z -- '.github/workflows/*.yml' | xargs -0 -t uvx yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'
+uvx checkov --framework=all --output=github_failed_only --directory=.


### PR DESCRIPTION
## Summary
- run `zizmor`, `yamllint`, and `checkov` through `uvx`
- retain the existing 7-day uv/npm/pnpm package cooldown
- preserve project-local `uv run` checks and native `actionlint`

## Rationale
This aligns local QA with the `opencode-action` pattern and applies `UV_EXCLUDE_NEWER` to ephemeral Python QA tools.