### PR TITLE
fix: correct Claude bot permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
       || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
       || (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
## Summary
- grant `contents: write` to the Claude mention-bot caller job
- keep the PR review job read-only
- retain `id-token: write`, which is part of the upstream Claude Code Action permission set

## Rationale
The reusable `claude-code-bot.yml` requests `contents: write`, but a reusable workflow cannot elevate `GITHUB_TOKEN` permissions above those granted by its caller. The caller currently grants only `contents: read`, preventing Claude from applying repository content changes when invoked by an authorized mention.

The reusable workflow already restricts execution to `OWNER`, `MEMBER`, or `COLLABORATOR` authors.